### PR TITLE
feat: set default region and sso region separately

### DIFF
--- a/feature-requests.md
+++ b/feature-requests.md
@@ -1,5 +1,4 @@
 - support china sso urls (https://start.${SSO_REGION}.home.awsapps.cn/directory/${COMPANY_NAME}#/)
 - add profile support
-- region on argument solution
-- set sso region and default regions separately
 - uninstall script
+- guide a new user through adding an sso


### PR DESCRIPTION
## 🚀 What does this PR do?

Add the possibility to set SSO region separately from default region.

### 🔍 Current behavior

The sso region will be the default region for all accounts.

### ✨ New behavior

The sso region and default region can be set separately when adding an SSO.

---

### 📝 Other information
