### PR TITLE
feat: start on add sso scren if no ssos

### DIFF
--- a/main.go
+++ b/main.go
@@ -396,6 +396,9 @@ func initialModel() model {
 	// Update the list items
 	if len(profiles) > 0 {
 		m.updateSSOList()
+	} else {
+		// If no profiles exist, start in the add state
+		m.state = stateAddSSO
 	}
 
 	return m


### PR DESCRIPTION
## 🚀 What does this PR do?

Sends the user to the add-sso screen if no existing ssos

### 🔍 Current behavior

Empty sso screen. The user will have to press "a" to add one themselves.

### ✨ New behavior

Automatically opens the add sso screen if no ssos are added.

---

### 📝 Other information
