### PR TITLE
chore: upped the maxAccountsForRoleLoading and added retry mechanic w…

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
@@ -25,6 +26,12 @@ type Client struct {
 func NewClient(region string) (*Client, error) {
 	cfg, err := config.LoadDefaultConfig(context.Background(),
 		config.WithRegion(region),
+		config.WithRetryer(func() aws.Retryer {
+			// Use standard retryer options but increase max attempts
+			return retry.NewStandard(func(o *retry.StandardOptions) {
+				o.MaxAttempts = 10
+			})
+		}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load SDK config: %w", err)

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ const (
 
 // Constants for limits
 const (
-	maxAccountsForRoleLoading = 30
+	maxAccountsForRoleLoading = 100
 	Version                   = "0.0.7"
 )
 


### PR DESCRIPTION
…ith a higher limit

## 🚀 What does this PR do?

Added "github.com/aws/aws-sdk-go-v2/aws/retry" and

```go
config.WithRetryer(func() aws.Retryer {
    // Use standard retryer options but increase max attempts
    return retry.NewStandard(func(o *retry.StandardOptions) {
    o.MaxAttempts = 10
  })
}),
```

This should hopefully solve the 429 errors that some people run into. I also bumped the `maxAccountsForRoleLoading` to 100 from 30. 

### 🔍 Current behavior

### ✨ New behavior

---

### 📝 Other information
