### PR TITLE
fix: prevent 'c' char copy from intercepting account filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -987,7 +987,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Add check for 'c' key press to copy verification code
 		case "c":
-			if m.state == stateSelectAccount && m.verificationCode != "" {
+			if m.state == stateSelectAccount && m.verificationCode != "" && m.accountList.FilterState() != list.Filtering {
 				return m, tea.SetClipboard(m.verificationCode)
 			}
 


### PR DESCRIPTION
Fixes #31 by adding a check in the copy handler to make sure we're not in the account filter
