### PR TITLE
Feat/profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Guidelines for awsesh
+
+## Build/Test Commands
+- **Build**: `go build -o awsesh` - Builds the binary to `awsesh`
+- **Test**: `go test ./...` - Runs all tests (currently no test files exist)
+- **Module**: `go mod tidy` - Clean up dependencies
+- **Lint**: No specific linter configured (use `go vet` for basic checks)
+
+## Code Style & Conventions
+- **Go version**: 1.23.0+ (uses Go 1.24.1 toolchain)
+- **Package structure**: Single module `awsesh` with subpackages `aws/`, `config/`, `utils/`
+- **Imports**: Group stdlib, external deps, then local packages (see main.go:3-26)
+- **Naming**: Use descriptive names, camelCase for unexported, PascalCase for exported
+- **Error handling**: Wrap errors with context using `fmt.Errorf("message: %w", err)`
+- **Constants**: Group related constants together, use descriptive names (main.go:17-44)
+
+## UI Framework (Bubble Tea)
+- Uses Bubble Tea v2 (beta) for TUI with Model-Update-View pattern
+- State management through `model` struct with explicit state constants
+- Message-driven architecture with typed messages (e.g., `fetchAccountsSuccessMsg`)
+- Use Bubbles library components: `list`, `textinput`, `spinner`
+- Apply dynamic theming via `getDynamicStyles()` function
+
+## Project Structure
+- `main.go`: Main application entry point and TUI logic
+- `aws/`: AWS SDK interactions (SSO, STS, account management)  
+- `config/`: Configuration file management and caching
+- `utils/`: Shared utilities (browser opening, etc.)
+- `.cursor/rules/`: Contains project-specific Cursor IDE rules
+
+## Key Patterns
+- Use context.Background() for AWS operations
+- Cache accounts/tokens to improve performance
+- Support both cached and fresh data flows
+- Sequential role loading for performance with large account lists
+- Comprehensive error handling with user-friendly messages

--- a/README.md
+++ b/README.md
@@ -19,12 +19,9 @@ _Editing, removing, managing SSO, setting region per account, and opening in bro
 - 🌐 Open the AWS console in your browser
 - 💅 Charming interactive terminal user interface
 - 🪶 Lightweight and easy to install
-- 🔧 Shell integration with automatic AWS_PROFILE environment variable setting
+- 🏷️ Profile support
 - ⭐ Compatible with shell prompt tools like Starship
 - 📁 XDG Base Directory specification compliance
-- 🔧 Respects AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE environment variables
-- 🏷️ Custom AWS profile name support (CLI flag and TUI option)
-- 🧠 Remembers profile names for account+role combinations
 
 ## 📋 Prerequisites
 
@@ -223,6 +220,7 @@ Use the `--eval` flag to set AWS environment variables in your shell for seamles
 Add this function to your shell configuration (`~/.bashrc`, `~/.zshrc`, etc.):
 
 **Bash/Zsh:**
+
 ```bash
 sesh() {
     eval "$(command sesh --eval "$@")"
@@ -230,6 +228,7 @@ sesh() {
 ```
 
 **Fish:**
+
 ```fish
 function sesh
     eval (command sesh --eval $argv)
@@ -242,7 +241,7 @@ end
 # CLI mode
 sesh MyOrg MyAccount AdminRole
 
-# TUI mode  
+# TUI mode
 sesh
 ```
 
@@ -250,7 +249,7 @@ This sets all AWS environment variables for compatibility with AWS tools and she
 
 ```bash
 export AWS_PROFILE='myorg-adminrole'
-export AWS_REGION='us-east-1' 
+export AWS_REGION='us-east-1'
 export AWS_ACCESS_KEY_ID='AKIA...'
 export AWS_SECRET_ACCESS_KEY='...'
 export AWS_SESSION_TOKEN='...'
@@ -262,6 +261,7 @@ export AWS_SESSION_EXPIRATION='2024-08-19T10:30:00Z'
 By default, `sesh` writes credentials to the `default` profile in your AWS credentials file. You can specify a custom profile name using the `--profile` flag.
 
 **CLI Usage:**
+
 ```bash
 # Use a custom profile name
 sesh MyOrg MyAccount AdminRole --profile production
@@ -274,7 +274,7 @@ In the interactive mode, when selecting a role, press `p` to enter a custom prof
 
 `sesh` remembers the custom profile names you use for specific account+role combinations:
 
-- **First time**: `sesh MyOrg MyAccount AdminRole --profile production` 
+- **First time**: `sesh MyOrg MyAccount AdminRole --profile production`
 - **Next time**: `sesh MyOrg MyAccount --profile production` (automatically uses AdminRole)
 - **TUI**: Press `p` on "MyAccount/AdminRole" → input pre-filled with "production"
 
@@ -302,20 +302,23 @@ This makes it easy to consistently use the same profile names for your different
 - `AWS_SHARED_CREDENTIALS_FILE` - Path to AWS credentials file (default: `~/.aws/credentials`)
 
 **Example XDG setup:**
+
 ```bash
 export AWS_CONFIG_FILE="$XDG_CONFIG_HOME/aws/config"
 export AWS_SHARED_CREDENTIALS_FILE="$XDG_DATA_HOME/aws/credentials"
 ```
 
 When these environment variables are set, `sesh` will:
+
 - Read existing SSO profiles from the custom config location
-- Write credentials to the custom credentials location  
+- Write credentials to the custom credentials location
 - Store its own configuration files (`awsesh`, `awsesh-tokens`, etc.) in the same directory as your AWS config file
 
 **Example with XDG compliance:**
+
 ```bash
 # Set XDG-compliant paths
-export AWS_CONFIG_FILE="$XDG_CONFIG_HOME/aws/config"  
+export AWS_CONFIG_FILE="$XDG_CONFIG_HOME/aws/config"
 export AWS_SHARED_CREDENTIALS_FILE="$XDG_DATA_HOME/aws/credentials"
 
 # Use sesh with shell integration

--- a/README.md
+++ b/README.md
@@ -214,15 +214,39 @@ sesh [-v|--version] [-b|--browser] [-w|--whoami] [-r|--region REGION] [-e|--eval
   sesh MyOrg MyAccount AdminRole --profile dev --eval
   ```
 
-### Shell Integration (AWS_PROFILE Environment Variable)
+### Shell Integration (AWS Environment Variables)
 
-For better integration with tools like [Starship](https://starship.rs/) that rely on the `AWS_PROFILE` environment variable, you can use the `--eval` flag to automatically set this variable in your shell.
+For better integration with tools like [Starship](https://starship.rs/) that display AWS session information, use the `--eval` flag to automatically set AWS environment variables in your shell.
 
-#### Setting up a shell function (Recommended)
+#### Recommended Setup: Simplified Shell Function
 
-Add this function to your shell configuration file (`~/.bashrc`, `~/.zshrc`, etc.):
+Add this simple function to your shell configuration file (`~/.bashrc`, `~/.zshrc`, etc.):
+
+**Bash/Zsh:**
+```bash
+sesh() {
+    eval "$(command sesh --eval "$@")"
+}
+```
+
+**Fish:**
+```fish
+function sesh
+    eval (command sesh --eval $argv)
+end
+```
 
 > **💡 Quick Setup:** You can also source the provided helper script: `source shell-integration.sh`
+
+This approach always uses `--eval` mode, which sets comprehensive AWS environment variables that work with:
+- ✅ **Starship** - Shows profile, region, and session duration
+- ✅ **AWS CLI** - Uses environment variables over credentials file
+- ✅ **Terraform** - Recognizes AWS environment variables
+- ✅ **Other AWS tools** - Standard environment variable support
+
+#### Advanced Setup: Conditional Shell Function
+
+For users who want both eval and file-only modes:
 
 **Bash/Zsh:**
 ```bash
@@ -249,11 +273,11 @@ end
 After setting up the function, you can use:
 
 ```sh
-# Set credentials AND AWS_PROFILE environment variable
-sesh MyOrg MyAccount AdminRole --eval
+# Direct CLI mode with comprehensive AWS environment variables
+sesh MyOrg MyAccount AdminRole
 
-# Or using the TUI with eval mode
-sesh --eval
+# Interactive TUI mode with comprehensive AWS environment variables
+sesh  # Shows TUI interface, sets all env vars after selection
 ```
 
 #### Manual usage (Alternative)
@@ -268,7 +292,18 @@ eval "$(sesh MyOrg MyAccount AdminRole --eval)"
 eval "$(sesh --eval)"
 ```
 
-The `--eval` flag makes `sesh` output shell commands like `export AWS_PROFILE='myorg-adminrole'` that set the environment variable to match your selected AWS account and role.
+The `--eval` flag makes `sesh` output comprehensive shell commands that set all relevant AWS environment variables:
+
+```bash
+export AWS_PROFILE='myorg-adminrole'
+export AWS_REGION='us-east-1'
+export AWS_ACCESS_KEY_ID='AKIA...'
+export AWS_SECRET_ACCESS_KEY='...'
+export AWS_SESSION_TOKEN='...'
+export AWS_SESSION_EXPIRATION='2024-08-19T10:30:00Z'
+```
+
+This provides complete session information for AWS tools and shell prompts like Starship.
 
 ### Custom Profile Names
 

--- a/README.md
+++ b/README.md
@@ -208,19 +208,19 @@ sesh [-v|--version] [-b|--browser] [-w|--whoami] [-r|--region REGION] [-e|--eval
   sesh MyOrg MyAccount --profile production
   ```
 
-- Combine custom profile name with shell integration:
+- Combine custom profile with shell integration:
 
   ```sh
-  sesh MyOrg MyAccount AdminRole --profile dev --eval
+  sesh MyOrg MyAccount AdminRole --profile dev
   ```
 
-### Shell Integration (AWS Environment Variables)
+### Shell Integration
 
-For better integration with tools like [Starship](https://starship.rs/) that display AWS session information, use the `--eval` flag to automatically set AWS environment variables in your shell.
+Use the `--eval` flag to set AWS environment variables in your shell for seamless integration with tools like [Starship](https://starship.rs/).
 
-#### Recommended Setup: Simplified Shell Function
+#### Setup
 
-Add this simple function to your shell configuration file (`~/.bashrc`, `~/.zshrc`, etc.):
+Add this function to your shell configuration (`~/.bashrc`, `~/.zshrc`, etc.):
 
 **Bash/Zsh:**
 ```bash
@@ -236,74 +236,26 @@ function sesh
 end
 ```
 
-> **💡 Quick Setup:** You can also source the provided helper script: `source shell-integration.sh`
-
-This approach always uses `--eval` mode, which sets comprehensive AWS environment variables that work with:
-- ✅ **Starship** - Shows profile, region, and session duration
-- ✅ **AWS CLI** - Uses environment variables over credentials file
-- ✅ **Terraform** - Recognizes AWS environment variables
-- ✅ **Other AWS tools** - Standard environment variable support
-
-#### Advanced Setup: Conditional Shell Function
-
-For users who want both eval and file-only modes:
-
-**Bash/Zsh:**
-```bash
-sesh() {
-    if [[ "$*" == *"--eval"* ]] || [[ "$*" == *"-e"* ]]; then
-        eval "$(command sesh "$@")"
-    else
-        command sesh "$@"
-    fi
-}
-```
-
-**Fish:**
-```fish
-function sesh
-    if string match -q "*--eval*" $argv; or string match -q "*-e*" $argv
-        eval (command sesh $argv)
-    else
-        command sesh $argv
-    end
-end
-```
-
-After setting up the function, you can use:
+#### Usage
 
 ```sh
-# Direct CLI mode with comprehensive AWS environment variables
+# CLI mode
 sesh MyOrg MyAccount AdminRole
 
-# Interactive TUI mode with comprehensive AWS environment variables
-sesh  # Shows TUI interface, sets all env vars after selection
+# TUI mode  
+sesh
 ```
 
-#### Manual usage (Alternative)
-
-If you prefer not to use a shell function, you can manually eval the output:
-
-```sh
-# Set credentials and capture the export command
-eval "$(sesh MyOrg MyAccount AdminRole --eval)"
-
-# Or with the TUI
-eval "$(sesh --eval)"
-```
-
-The `--eval` flag makes `sesh` output comprehensive shell commands that set all relevant AWS environment variables:
+This sets all AWS environment variables for compatibility with AWS tools and shell prompts:
 
 ```bash
 export AWS_PROFILE='myorg-adminrole'
-export AWS_REGION='us-east-1'
+export AWS_REGION='us-east-1' 
 export AWS_ACCESS_KEY_ID='AKIA...'
 export AWS_SECRET_ACCESS_KEY='...'
 export AWS_SESSION_TOKEN='...'
 export AWS_SESSION_EXPIRATION='2024-08-19T10:30:00Z'
 ```
-
-This provides complete session information for AWS tools and shell prompts like Starship.
 
 ### Custom Profile Names
 
@@ -313,9 +265,6 @@ By default, `sesh` writes credentials to the `default` profile in your AWS crede
 ```bash
 # Use a custom profile name
 sesh MyOrg MyAccount AdminRole --profile production
-
-# Combine with eval flag to set both credentials and AWS_PROFILE
-eval "$(sesh MyOrg MyAccount AdminRole --profile dev --eval)"
 ```
 
 **TUI Usage:**
@@ -333,9 +282,9 @@ This makes it easy to consistently use the same profile names for your different
 
 #### Profile Naming Convention
 
-- **Default behavior**: Credentials are written to the `default` profile
-- **With `--profile` flag**: Credentials are written to your specified profile name
-- **With `--eval` flag**: `AWS_PROFILE` is set to the profile name used (either "default" or your custom name)
+- **Default behavior**: Uses the `default` profile
+- **With `--profile` flag**: Uses your specified profile name
+- **Shell integration**: Automatically sets `AWS_PROFILE` environment variable
 
 ### Important Notes
 
@@ -363,18 +312,18 @@ When these environment variables are set, `sesh` will:
 - Write credentials to the custom credentials location  
 - Store its own configuration files (`awsesh`, `awsesh-tokens`, etc.) in the same directory as your AWS config file
 
-**Example combining XDG compliance with shell integration:**
+**Example with XDG compliance:**
 ```bash
 # Set XDG-compliant paths
 export AWS_CONFIG_FILE="$XDG_CONFIG_HOME/aws/config"  
 export AWS_SHARED_CREDENTIALS_FILE="$XDG_DATA_HOME/aws/credentials"
 
-# Use sesh with eval mode
-sesh MyOrg MyAccount AdminRole --eval
+# Use sesh with shell integration
+sesh MyOrg MyAccount AdminRole
 
-# Now both the credentials file and AWS_PROFILE are set correctly
+# Credentials file and environment variables are set
 echo $AWS_PROFILE  # Output: myorg-adminrole
-aws sts get-caller-identity  # Uses credentials from custom location
+aws sts get-caller-identity  # Works with custom location
 ```
 
 > **💡 Note for XDG users:** If you have `AWS_CONFIG_FILE` set but your SSO profiles don't appear, make sure your existing SSO profiles are in the file specified by that environment variable, not in `~/.aws/config`.

--- a/main.go
+++ b/main.go
@@ -1571,8 +1571,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case credentialsSetMsg:
 		// Handle eval flag for shell integration
 		if globalEvalMode {
-			// Create styled success message for TUI eval mode with simpler border
-			// to avoid lipgloss box rendering issues after TUI stderr usage
+			// Create clean styled success message for TUI eval mode without borders
+			// This avoids ANSI padding calculation issues and looks cleaner
 			cliStyles := getDynamicStyles(true) // Assume dark background for CLI output
 
 			// Determine region: account-specific > SSO default
@@ -1584,36 +1584,26 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Clear screen and reset terminal state for clean appearance after TUI exit
 			fmt.Fprintf(os.Stderr, "\033[2J\033[H\033[0m") // Clear screen, home cursor, reset all attributes
 
-			// Print success message with colors and properly formatted box
+			// Print clean success message with colors (no borders for cleaner output)
 			fmt.Fprintf(os.Stderr, "\r\n")
-			fmt.Fprintf(os.Stderr, "\r%s\n", cliStyles.successText.Render("╭──────────────────────────────────────────╮"))
-			fmt.Fprintf(os.Stderr, "\r%s\n", cliStyles.successText.Render("│                                          │"))
 
-			// Format each line with proper padding to fit the box width (40 chars content + 2 for borders)
-			ssoLine := fmt.Sprintf("SSO Profile: %s", cliStyles.primary.Render(m.selectedSSO.Name))
-			fmt.Fprintf(os.Stderr, "\r%s %-38s %s\n",
-				cliStyles.successText.Render("│"), ssoLine, cliStyles.successText.Render("│"))
+			ssoLine := fmt.Sprintf("  SSO Profile: %s", cliStyles.primary.Bold(true).Render(m.selectedSSO.Name))
+			fmt.Fprintf(os.Stderr, "\r%s\n", ssoLine)
 
-			accountLine := fmt.Sprintf("Account: %s (%s)", cliStyles.primary.Render(m.selectedAcc.Name), cliStyles.muted.Render(m.selectedAcc.AccountID))
-			fmt.Fprintf(os.Stderr, "\r%s %-38s %s\n",
-				cliStyles.successText.Render("│"), accountLine, cliStyles.successText.Render("│"))
+			accountLine := fmt.Sprintf("  Account: %s %s", cliStyles.primary.Bold(true).Render(m.selectedAcc.Name), cliStyles.muted.Render(fmt.Sprintf("(%s)", m.selectedAcc.AccountID)))
+			fmt.Fprintf(os.Stderr, "\r%s\n", accountLine)
 
-			roleLine := fmt.Sprintf("Role: %s", cliStyles.primary.Render(m.selectedAcc.SelectedRole))
-			fmt.Fprintf(os.Stderr, "\r%s %-38s %s\n",
-				cliStyles.successText.Render("│"), roleLine, cliStyles.successText.Render("│"))
+			roleLine := fmt.Sprintf("  Role: %s", cliStyles.primary.Bold(true).Render(m.selectedAcc.SelectedRole))
+			fmt.Fprintf(os.Stderr, "\r%s\n", roleLine)
 
-			regionLine := fmt.Sprintf("Region: %s", cliStyles.primary.Render(region))
-			fmt.Fprintf(os.Stderr, "\r%s %-38s %s\n",
-				cliStyles.successText.Render("│"), regionLine, cliStyles.successText.Render("│"))
+			regionLine := fmt.Sprintf("  Region: %s", cliStyles.primary.Bold(true).Render(region))
+			fmt.Fprintf(os.Stderr, "\r%s\n", regionLine)
 
 			if msg.profileName != "default" {
-				profileLine := fmt.Sprintf("AWS Profile: %s", cliStyles.primary.Render(msg.profileName))
-				fmt.Fprintf(os.Stderr, "\r%s %-38s %s\n",
-					cliStyles.successText.Render("│"), profileLine, cliStyles.successText.Render("│"))
+				profileLine := fmt.Sprintf("  AWS Profile: %s", cliStyles.primary.Bold(true).Render(msg.profileName))
+				fmt.Fprintf(os.Stderr, "\r%s\n", profileLine)
 			}
 
-			fmt.Fprintf(os.Stderr, "\r%s\n", cliStyles.successText.Render("│                                          │"))
-			fmt.Fprintf(os.Stderr, "\r%s\n", cliStyles.successText.Render("╰──────────────────────────────────────────╯"))
 			fmt.Fprintf(os.Stderr, "\r\n")
 
 			// Output shell commands to stdout (gets eval'd)

--- a/shell-integration.sh
+++ b/shell-integration.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Shell integration helper for awsesh
+# This file provides shell functions to enable comprehensive AWS environment variable setting
+
+# Recommended: Simple function that always uses --eval mode (best for Starship integration)
+sesh() {
+    eval "$(command sesh --eval "$@")"
+}
+
+# Alternative: Conditional function for users who want both eval and file-only modes
+# Uncomment the function above and comment out this one if you prefer the simple approach
+# sesh() {
+#     if [[ "$*" == *"--eval"* ]] || [[ "$*" == *"-e"* ]]; then
+#         eval "$(command sesh "$@")"
+#     else
+#         command sesh "$@"
+#     fi
+# }
+
+# Fish shell function (copy to ~/.config/fish/functions/sesh.fish if using fish)
+# Simple version:
+# function sesh
+#     eval (command sesh --eval $argv)
+# end
+#
+# Conditional version:
+# function sesh
+#     if string match -q "*--eval*" $argv; or string match -q "*-e*" $argv
+#         eval (command sesh $argv)
+#     else
+#         command sesh $argv
+#     end
+# end
+
+echo "Shell integration loaded! The --eval mode sets comprehensive AWS environment variables:"
+echo "  AWS_PROFILE, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_SESSION_EXPIRATION"
+echo ""
+echo "You can now use:"
+echo "  sesh                     # Interactive mode with full environment setup"
+echo "  sesh MyOrg MyAccount     # Direct mode with full environment setup"
+echo ""
+echo "Current AWS session:"
+echo "  AWS_PROFILE: ${AWS_PROFILE:-<not set>}"
+echo "  AWS_REGION: ${AWS_REGION:-<not set>}"


### PR DESCRIPTION
## 🚀 What does this PR do?

* Adds functionality to set a profile
* Adds an `--eval` flag to allow users to set environment variables in their shells
* Adds XDG compatability

### 🔍 Current behavior

### ✨ New behavior

- Use a custom profile name for your credentials:
  ```sh
  sesh MyOrg MyAccount AdminRole --profile production
  ```
- Use custom profile with last used role (no need to specify role):
  ```sh
  sesh MyOrg MyAccount --profile production
  ```

You can set a short script in your shell to always run sesh in eval mode:

```sh
sesh() {
    eval "$(command sesh --eval "$@")"
}
```

and that allows you to set the aws env vars in your shell which for example Starship can pick up and display:
(default being the profile set, then the duration of the token and lastly an alias for eu-west-1)

<img width="1147" height="143" alt="Screenshot 2025-08-19 at 12 11 48" src="https://github.com/user-attachments/assets/77be7722-c19d-4205-90e9-9650a8b38ffc" />


---

### 📝 Other information
