### PR TITLE
fix: add explicit version to Homebrew formula template

### DIFF
--- a/homebrew/formula/awsesh.rb.in
+++ b/homebrew/formula/awsesh.rb.in
@@ -2,6 +2,7 @@ class Awsesh < Formula
   desc "AWS Session Manager CLI"
   homepage "https://github.com/elva-labs/awsesh"
   license "MIT"
+  version "__VERSION__"
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Prevents Homebrew from incorrectly inferring version '64' from 'amd64' in binary filename

## 🚀 What does this PR do?

Fixes Homebrew showing version "64" instead of the actual version like "v.0.1.6".

### 🔍 Current behavior

`brew info awsesh` shows `stable 64` because Homebrew sees "amd64" in the filename and thinks "64" is the version.

### ✨ New behavior

`brew info awsesh` will show the correct version like `stable v.0.1.6` by explicitly telling Homebrew what version it is.

---

### 📝 Other information

Takes effect on next release. Current installs still show "64" until upgraded.