### PR TITLE
feat: add manual refresh and cache eviction of permission sets

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -105,13 +106,17 @@ func (c *Client) ListAccounts(ctx context.Context, accessToken string, existingA
 		// Create account objects, preserving existing roles if available
 		for _, acc := range resp.AccountList {
 			accountID := *acc.AccountId
+			accountName := *acc.AccountName
+
 			if existingAcc, exists := existingMap[accountID]; exists {
-				// Preserve existing account data
-				accounts = append(accounts, existingAcc)
+				// Update account name in case it changed, but preserve roles and region
+				updatedAcc := existingAcc
+				updatedAcc.Name = accountName
+				accounts = append(accounts, updatedAcc)
 			} else {
 				// Create new account with empty roles
 				accounts = append(accounts, Account{
-					Name:        *acc.AccountName,
+					Name:        accountName,
 					AccountID:   accountID,
 					Roles:       []string{},
 					RolesLoaded: false,
@@ -124,6 +129,11 @@ func (c *Client) ListAccounts(ctx context.Context, accessToken string, existingA
 			break
 		}
 	}
+
+	// Sort accounts by name to ensure consistent order
+	slices.SortFunc(accounts, func(a, b Account) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return accounts, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -105,32 +105,35 @@ func (m *Manager) SaveCachedAccounts(profileName, startURL string, accounts []aw
 }
 
 // LoadCachedAccounts loads cached accounts for a specific SSO profile
-func (m *Manager) LoadCachedAccounts(startURL string) ([]awsclient.Account, time.Time, error) {
+// Returns accounts, lastUpdated time, isStale boolean (true if older than 24h), and error
+func (m *Manager) LoadCachedAccounts(startURL string) ([]awsclient.Account, time.Time, bool, error) {
 	cachePath, err := getAwseshAccountsCachePath()
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, false, err
 	}
 
 	data, err := os.ReadFile(cachePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, time.Time{}, nil
+			return nil, time.Time{}, false, nil
 		}
-		return nil, time.Time{}, fmt.Errorf("failed to read accounts cache: %w", err)
+		return nil, time.Time{}, false, fmt.Errorf("failed to read accounts cache: %w", err)
 	}
 
 	var allCaches []CachedAccounts
 	if err = json.Unmarshal(data, &allCaches); err != nil {
-		return nil, time.Time{}, fmt.Errorf("failed to parse accounts cache: %w", err)
+		return nil, time.Time{}, false, fmt.Errorf("failed to parse accounts cache: %w", err)
 	}
 
 	for _, cache := range allCaches {
 		if cache.StartURL == startURL {
-			return cache.Accounts, cache.LastUpdated, nil
+			// Check if cache is stale (older than 24 hours)
+			isStale := time.Since(cache.LastUpdated) > 24*time.Hour
+			return cache.Accounts, cache.LastUpdated, isStale, nil
 		}
 	}
 
-	return nil, time.Time{}, nil
+	return nil, time.Time{}, false, nil
 }
 
 // Helper function to get the accounts cache file path

--- a/main.go
+++ b/main.go
@@ -346,6 +346,10 @@ func initialModel() model {
 				key.WithHelp("p", "custom profile"),
 			),
 			key.NewBinding(
+				key.WithKeys("r"),
+				key.WithHelp("r", "refresh roles"),
+			),
+			key.NewBinding(
 				key.WithKeys("o"),
 				key.WithHelp("o", "open browser"),
 			),
@@ -360,6 +364,10 @@ func initialModel() model {
 			key.NewBinding(
 				key.WithKeys("enter"),
 				key.WithHelp("enter", "select role and set session"),
+			),
+			key.NewBinding(
+				key.WithKeys("r"),
+				key.WithHelp("r", "refresh roles from AWS"),
 			),
 			key.NewBinding(
 				key.WithKeys("o"),
@@ -1055,6 +1063,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						}
 					}
 				}
+			} else if m.state == stateSelectRole && m.roleList.FilterState() != list.Filtering {
+				// Force refresh roles for the current account
+				if m.selectedAcc != nil {
+					// Reset RolesLoaded flag to force a fresh fetch
+					for idx := range m.accounts {
+						if m.accounts[idx].AccountID == m.selectedAcc.AccountID {
+							m.accounts[idx].RolesLoaded = false
+							m.loadingText = fmt.Sprintf("Refreshing roles for %s...", m.selectedAcc.Name)
+							return m, loadAccountRoles(m.awsClient, m.accessToken, m.selectedAcc.AccountID, idx)
+						}
+					}
+				}
 			}
 
 		// Add check for 'c' key press to copy verification code
@@ -1196,13 +1216,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 									}
 
 									// Load cached accounts if they exist
-									cachedAccounts, lastUpdated, err := m.configMgr.LoadCachedAccounts(profile.StartURL)
+									cachedAccounts, lastUpdated, isStale, err := m.configMgr.LoadCachedAccounts(profile.StartURL)
 									if err != nil {
 										fmt.Fprintf(os.Stderr, "Warning: Failed to load cached accounts: %v\n", err)
 									}
 
 									// If we have cached accounts, use them
 									if len(cachedAccounts) > 0 {
+										// If cache is stale (>24h), reset RolesLoaded flags to trigger background refresh
+										if isStale {
+											for i := range cachedAccounts {
+												cachedAccounts[i].RolesLoaded = false
+											}
+										}
+
 										m.accounts = cachedAccounts
 										m.accountsLastUpdated = lastUpdated
 										m.usingCachedAccounts = true

--- a/main.go
+++ b/main.go
@@ -311,6 +311,10 @@ func initialModel() model {
 				key.WithHelp("r", "set region"),
 			),
 			key.NewBinding(
+				key.WithKeys("R"),
+				key.WithHelp("R", "refresh accounts"),
+			),
+			key.NewBinding(
 				key.WithKeys("o"),
 				key.WithHelp("o", "open in browser"),
 			),
@@ -321,6 +325,10 @@ func initialModel() model {
 			key.NewBinding(
 				key.WithKeys("r"),
 				key.WithHelp("r", "set region for selected account"),
+			),
+			key.NewBinding(
+				key.WithKeys("R"),
+				key.WithHelp("R", "refresh accounts from AWS"),
 			),
 			key.NewBinding(
 				key.WithKeys("o"),
@@ -544,7 +552,7 @@ func makeAccountItems(accounts []aws.Account, ssoDefaultRegion string, configMgr
 		}
 	}
 
-	sortItems(accountItems)
+	// Accounts are already sorted in ListAccounts, no need to sort items again
 	return accountItems
 }
 
@@ -1050,6 +1058,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "r":
 			if m.state == stateSelectAccount && m.accountList.FilterState() != list.Filtering {
+				// r: Set region for selected account
 				if i, ok := m.accountList.SelectedItem().(item); ok {
 					for idx, acc := range m.accounts {
 						if acc.Name == i.Title() {
@@ -1064,7 +1073,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 			} else if m.state == stateSelectRole && m.roleList.FilterState() != list.Filtering {
-				// Force refresh roles for the current account
+				// r: Refresh roles for the current account
 				if m.selectedAcc != nil {
 					// Reset RolesLoaded flag to force a fresh fetch
 					for idx := range m.accounts {
@@ -1074,6 +1083,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							return m, loadAccountRoles(m.awsClient, m.accessToken, m.selectedAcc.AccountID, idx)
 						}
 					}
+				}
+			}
+
+		case "R":
+			if m.state == stateSelectAccount && m.accountList.FilterState() != list.Filtering {
+				// R (Shift+r): Refresh account list
+				if m.selectedSSO != nil && m.accessToken != "" {
+					newRequestID := fmt.Sprintf("%s-refresh-%d", m.selectedSSO.Name, time.Now().UnixNano())
+					m.currentRequestID = newRequestID
+					m.loadingText = "Refreshing accounts..."
+					return m, tea.Batch(
+						fetchAccounts(m.awsClient, m.accessToken, newRequestID, nil),
+						m.spinner.Tick,
+					)
 				}
 			}
 
@@ -1528,6 +1551,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loadingText = "SSO login successful! Fetching accounts..."
 		m.errorMessage = ""
 		m.isAuthenticating = false // Reset authentication flag
+		// Pass existing accounts to preserve roles during background refresh
 		return m, fetchAccounts(m.awsClient, m.accessToken, m.currentRequestID, m.accounts)
 
 	case ssoLoginErrMsg:
@@ -1555,36 +1579,68 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}()
 		}
 
-		// If we're using cached accounts, just update the accounts in memory
-		// but don't change the view or state
-		if m.usingCachedAccounts {
-			m.accounts = msg.accounts
-			m.accountList.Title = fmt.Sprintf("Select AWS Account for %s", m.selectedSSO.Name)
-			return m, nil
-		}
-
-		// For non-cached accounts, proceed with normal flow
+		// Update accounts in memory
 		m.accounts = msg.accounts
-		m.state = stateSelectAccount
-		m.errorMessage = ""
-		m.usingCachedAccounts = false
-		m.loadingText = ""
 
-		// Create account list items
+		// Create account list items with updated data
 		accountItems := makeAccountItems(m.accounts, m.selectedSSO.DefaultRegion, m.configMgr, m.selectedSSO.Name)
 
-		// Update account list title with breadcrumb and role loading status
-		title := fmt.Sprintf("Select AWS Account for %s", m.selectedSSO.Name)
-		m.accountList.Title = title
+		// If we're using cached accounts, preserve the user's current selection
+		var currentlySelectedAccountName string
+		if m.usingCachedAccounts {
+			if selectedItem, ok := m.accountList.SelectedItem().(item); ok {
+				currentlySelectedAccountName = selectedItem.Title()
+			}
+		}
+
 		m.accountList.SetItems(accountItems)
 
-		// Try to select the previously selected account if it exists
-		m.selectLastUsedAccount(m.selectedSSO.Name)
+		// Update account list title
+		m.accountList.Title = fmt.Sprintf("Select AWS Account for %s", m.selectedSSO.Name)
 
-		// Start sequential role loading only if we're under the limit
-		if len(m.accounts) <= maxAccountsForRoleLoading {
-			return m, startLoadingRoles(m.accessToken, m.accounts)
+		// Only change state if we weren't showing cached accounts
+		if !m.usingCachedAccounts {
+			m.state = stateSelectAccount
+			m.errorMessage = ""
+			m.loadingText = ""
+
+			// Try to select the previously selected account
+			m.selectLastUsedAccount(m.selectedSSO.Name)
+
+			// Start sequential role loading only if we're under the limit
+			if len(m.accounts) <= maxAccountsForRoleLoading {
+				return m, startLoadingRoles(m.accessToken, m.accounts)
+			}
+		} else {
+			// Background refresh complete - preserve user's selection
+			if currentlySelectedAccountName != "" {
+				for i, listItem := range m.accountList.Items() {
+					if listItem.(item).Title() == currentlySelectedAccountName {
+						m.accountList.Select(i)
+						break
+					}
+				}
+			}
+
+			m.usingCachedAccounts = false
+			m.loadingText = ""
+
+			// Only start loading roles for accounts that don't have them yet
+			if len(m.accounts) <= maxAccountsForRoleLoading {
+				// Check if there are any accounts without roles loaded
+				needsRoleLoading := false
+				for _, acc := range m.accounts {
+					if !acc.RolesLoaded {
+						needsRoleLoading = true
+						break
+					}
+				}
+				if needsRoleLoading {
+					return m, startLoadingRoles(m.accessToken, m.accounts)
+				}
+			}
 		}
+
 		return m, nil
 
 	case fetchAccountsErrMsg:


### PR DESCRIPTION
Add shortcut (`r`) in Role Selection window to manually refresh role list, and expire cached roles after 24 hours

closes #30 