### PR TITLE
fix: use correct release asset name in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,15 +32,16 @@ if [ -z "$LATEST_VERSION" ]; then
 fi
 
 # Construct the binary name
-BINARY_NAME="sesh-${OS}-${ARCH}"
-if [ "$OS" = "darwin" ]; then
-    BINARY_NAME="sesh-darwin-${ARCH}"
-elif [ "$OS" = "linux" ]; then
-    BINARY_NAME="sesh-linux-${ARCH}"
-else
-    echo "Unsupported operating system: $OS"
-    exit 1
-fi
+BINARY_PREFIX="awsesh"
+case "$OS" in
+    darwin|linux)
+        BINARY_NAME="${BINARY_PREFIX}-${OS}-${ARCH}"
+        ;;
+    *)
+        echo "Unsupported operating system: $OS"
+        exit 1
+        ;;
+esac
 
 # Download URL
 DOWNLOAD_URL="https://github.com/elva-labs/awsesh/releases/download/${LATEST_VERSION}/${BINARY_NAME}"
@@ -78,4 +79,4 @@ fi
 cd - > /dev/null
 rm -rf "$TMP_DIR"
 
-echo "Installation complete! You can now use 'sesh' from the command line." 
+echo "Installation complete! You can now use 'sesh' from the command line."


### PR DESCRIPTION
## 🚀 What does this PR do?
Solve an issue on macos install.sh execution

### 🔍 Current behavior

```
sesh
/usr/local/bin/sesh: line 1: Not: command not found
```

### ✨ New behavior

Works
<img width="387" height="96" alt="image" src="https://github.com/user-attachments/assets/7d03458f-2db6-4357-a7d6-1dcec17beffc" />

---

### 📝 Other information
