### PR TITLE
feat: add -b to open browser with default profile

### DIFF
--- a/packages/awsesh/src/cli/cmd/cli-integration.test.ts
+++ b/packages/awsesh/src/cli/cmd/cli-integration.test.ts
@@ -102,6 +102,14 @@ describe("CLI", () => {
     });
   });
 
+  describe("root browser flag", () => {
+    test("exits with error when default profile is not active", async () => {
+      const { stderr, exitCode } = await runCli(["-b"], testEnv("root-browser-no-default"));
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("No active credentials found for profile 'default'");
+    });
+  });
+
   describe("direct session command", () => {
     test("resolves positional args to session command", async () => {
       const { stderr, exitCode } = await runCli(["missing-session", "account", "role"], testEnv("session-direct"));

--- a/packages/awsesh/src/cli/cmd/tui/thread.ts
+++ b/packages/awsesh/src/cli/cmd/tui/thread.ts
@@ -1,10 +1,23 @@
 import { cmd } from "../cmd"
+import { openDefaultProfileInBrowser } from "../util/open-default-profile-browser"
 
 export const TuiCommand = cmd({
   command: "$0",
   describe: "Interactive AWS Session Manager",
-  builder: (yargs) => yargs,
-  handler: async () => {
+  builder: (yargs) =>
+    yargs.option("browser", {
+      alias: "b",
+      type: "boolean",
+      describe: "Open AWS console for active default profile",
+      default: false,
+    }),
+  handler: async (args) => {
+    const { browser } = args as { browser: boolean }
+    if (browser) {
+      await openDefaultProfileInBrowser()
+      return
+    }
+
     const { tui } = await import("./app")
     await tui()
   },

--- a/packages/awsesh/src/cli/cmd/util/open-default-profile-browser.ts
+++ b/packages/awsesh/src/cli/cmd/util/open-default-profile-browser.ts
@@ -1,0 +1,29 @@
+import { UI } from "@/cli/ui"
+import { getAwsesh } from "@/instance"
+import { openBrowser } from "@/util/browser"
+
+export async function openDefaultProfileInBrowser(): Promise<void> {
+  const awsesh = getAwsesh()
+  const activeCredentials = await awsesh.activeCredentials.list()
+  const credential =
+    activeCredentials.find((activeCredential) => activeCredential.isDefault) ||
+    activeCredentials.find((activeCredential) => activeCredential.profileName === "default")
+
+  if (!credential) {
+    UI.error("No active credentials found for profile 'default'.")
+    UI.info("Run 'awsesh set' to configure credentials for the default profile.")
+    process.exit(1)
+  }
+  const session = await awsesh.sessions.get(credential.sessionName)
+
+  if (!session) {
+    UI.error(`SSO session '${credential.sessionName}' not found.`)
+    UI.info("Run 'awsesh sessions' to see available sessions.")
+    process.exit(1)
+  }
+
+  const url = awsesh.sso.getAccountUrl(session, credential.accountId, "", credential.roleName)
+  UI.info("Opening AWS console in browser...")
+  await openBrowser(url)
+  UI.success("Browser opened successfully!")
+}


### PR DESCRIPTION
You can now run `awsesh -b` to open your default profile in the browser. One of my favorite convenient features of the go version.