### PR TITLE
chore(core): move storage handling to use node apis instead of bun

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,0 +1,47 @@
+import path from "node:path"
+import fs from "node:fs/promises"
+
+export async function readJsonFile<T>(filePath: string): Promise<T> {
+  const content = await fs.readFile(filePath, "utf-8")
+  return JSON.parse(content) as T
+}
+
+export async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await fs.writeFile(filePath, JSON.stringify(value, null, 2))
+}
+
+export async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function listJsonFiles(
+  dir: string,
+  options: { recursive?: boolean } = {}
+): Promise<string[]> {
+  const recursive = options.recursive ?? false
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name)
+
+    if (entry.isFile() && entry.name.endsWith(".json")) {
+      files.push(entry.name)
+      continue
+    }
+
+    if (recursive && entry.isDirectory()) {
+      const nestedFiles = await listJsonFiles(entryPath, { recursive: true })
+      for (const nestedFile of nestedFiles) {
+        files.push(path.posix.join(entry.name, nestedFile))
+      }
+    }
+  }
+
+  return files
+}

--- a/packages/core/src/sessions.test.ts
+++ b/packages/core/src/sessions.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import path from "node:path";
 import fs from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { Sessions } from "../src/sessions";
 import type { SSOSession } from "../src/types";
+
+const execFileAsync = promisify(execFile);
 
 describe("Sessions", () => {
   let tempDir: string;
@@ -30,7 +34,7 @@ describe("Sessions", () => {
       await sessions.save(sampleSession);
 
       const filePath = path.join(tempDir, "my-sso.json");
-      const content = await Bun.file(filePath).text();
+      const content = await fs.readFile(filePath, "utf-8");
       expect(content).toContain('"name": "my-sso"');
       expect(content).toContain('"startUrl": "https://my-sso.awsapps.com/start"');
     });
@@ -42,7 +46,7 @@ describe("Sessions", () => {
       await nestedSessions.save(sampleSession);
 
       const filePath = path.join(nestedDir, "my-sso.json");
-      const exists = await Bun.file(filePath).exists();
+      const exists = await fs.access(filePath).then(() => true).catch(() => false);
       expect(exists).toBe(true);
     });
 
@@ -111,12 +115,50 @@ describe("Sessions", () => {
     });
 
     test("ignores non-JSON files", async () => {
-      await Bun.write(path.join(tempDir, "readme.txt"), "not a session");
+      await fs.writeFile(path.join(tempDir, "readme.txt"), "not a session");
       await sessions.save(sampleSession);
 
       const result = await sessions.list();
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe("my-sso");
+    });
+
+    test("works when consumed from Node runtime", async () => {
+      await sessions.save({ ...sampleSession, name: "node-only" });
+
+      const buildDir = path.join(tempDir, "node-build");
+      await fs.mkdir(buildDir, { recursive: true });
+
+      const buildResult = await Bun.build({
+        entrypoints: [path.join(import.meta.dir, "..", "src", "sessions.ts")],
+        outdir: buildDir,
+        format: "esm",
+        target: "node",
+      });
+
+      expect(buildResult.success).toBe(true);
+
+      const bundlePath = path.join(buildDir, "sessions.js");
+      const nodeScript = [
+        "import { pathToFileURL } from 'node:url'",
+        "const { Sessions } = await import(pathToFileURL(process.argv[1]).href)",
+        "const sessions = Sessions.create({ dir: process.argv[2] })",
+        "const list = await sessions.list()",
+        "const count = await sessions.count()",
+        "process.stdout.write(JSON.stringify({ names: list.map((x) => x.name).sort(), count }))",
+      ].join("; ");
+
+      const { stdout } = await execFileAsync("node", [
+        "--input-type=module",
+        "--eval",
+        nodeScript,
+        bundlePath,
+        tempDir,
+      ]);
+
+      const result = JSON.parse(stdout) as { names: string[]; count: number };
+      expect(result.names).toEqual(["node-only"]);
+      expect(result.count).toBe(1);
     });
   });
 

--- a/packages/core/src/sessions.ts
+++ b/packages/core/src/sessions.ts
@@ -1,6 +1,7 @@
 import path from "node:path"
 import fs from "node:fs/promises"
 import type { SSOSession } from "./types"
+import { fileExists, listJsonFiles, readJsonFile, writeJsonFile } from "./filesystem"
 
 export interface SessionsOptions {
   dir: string
@@ -18,13 +19,10 @@ export namespace Sessions {
       async list(): Promise<SSOSession[]> {
         try {
           await ensureDir()
-          const glob = new Bun.Glob("*.json")
-          const files = await Array.fromAsync(
-            glob.scan({ cwd: dir, onlyFiles: true })
-          )
+          const files = await listJsonFiles(dir)
 
           const sessions = await Promise.all(
-            files.map((file) => Bun.file(path.join(dir, file)).json() as Promise<SSOSession>)
+            files.map((file) => readJsonFile<SSOSession>(path.join(dir, file)))
           )
 
           return sessions
@@ -35,15 +33,14 @@ export namespace Sessions {
 
       async load(name: string): Promise<SSOSession | undefined> {
         const target = path.join(dir, `${name}.json`)
-        const file = Bun.file(target)
-        if (!(await file.exists())) return undefined
-        return file.json() as Promise<SSOSession>
+        if (!(await fileExists(target))) return undefined
+        return readJsonFile<SSOSession>(target)
       },
 
       async save(session: SSOSession): Promise<void> {
         await ensureDir()
         const target = path.join(dir, `${session.name}.json`)
-        await Bun.write(target, JSON.stringify(session, null, 2))
+        await writeJsonFile(target, session)
       },
 
       async remove(name: string): Promise<void> {
@@ -53,16 +50,13 @@ export namespace Sessions {
 
       async exists(name: string): Promise<boolean> {
         const target = path.join(dir, `${name}.json`)
-        return Bun.file(target).exists()
+        return fileExists(target)
       },
 
       async count(): Promise<number> {
         try {
           await ensureDir()
-          const glob = new Bun.Glob("*.json")
-          const files = await Array.fromAsync(
-            glob.scan({ cwd: dir, onlyFiles: true })
-          )
+          const files = await listJsonFiles(dir)
           return files.length
         } catch {
           return 0

--- a/packages/core/src/storage.test.ts
+++ b/packages/core/src/storage.test.ts
@@ -37,7 +37,7 @@ describe("Storage", () => {
       await storage.write("my-key", { hello: "world" });
 
       const filePath = path.join(tempDir, "my-key.json");
-      const content = await Bun.file(filePath).text();
+      const content = await fs.readFile(filePath, "utf-8");
       expect(content).toContain('"hello": "world"');
     });
 
@@ -45,7 +45,7 @@ describe("Storage", () => {
       await storage.write("nested/deep/key", { value: 123 });
 
       const filePath = path.join(tempDir, "nested", "deep", "key.json");
-      const content = await Bun.file(filePath).text();
+      const content = await fs.readFile(filePath, "utf-8");
       expect(content).toContain('"value": 123');
     });
 

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -1,5 +1,6 @@
 import path from "node:path"
 import fs from "node:fs/promises"
+import { listJsonFiles, readJsonFile, writeJsonFile } from "./filesystem"
 
 export interface StorageOptions {
   dir: string
@@ -17,9 +18,7 @@ export namespace Storage {
       async read<T>(key: string): Promise<T | undefined> {
         const target = path.join(dir, `${key}.json`)
         try {
-          const file = Bun.file(target)
-          if (!(await file.exists())) return undefined
-          return file.json() as Promise<T>
+          return await readJsonFile<T>(target)
         } catch {
           return undefined
         }
@@ -28,22 +27,21 @@ export namespace Storage {
       async write<T>(key: string, value: T): Promise<void> {
         const target = path.join(dir, `${key}.json`)
         await ensureDir(path.dirname(target))
-        await Bun.write(target, JSON.stringify(value, null, 2))
+        await writeJsonFile(target, value)
       },
 
       async update<T>(key: string, fn: (existing: T) => T): Promise<T> {
         const target = path.join(dir, `${key}.json`)
         let content: T
         try {
-          const file = Bun.file(target)
-          content = await file.json() as T
+          content = await readJsonFile<T>(target)
         } catch {
           content = {} as T
         }
 
         const updated = fn(content)
         await ensureDir(path.dirname(target))
-        await Bun.write(target, JSON.stringify(updated, null, 2))
+        await writeJsonFile(target, updated)
         return updated
       },
 
@@ -60,10 +58,7 @@ export namespace Storage {
       async list(prefix: string): Promise<string[]> {
         const targetDir = path.join(dir, prefix)
         try {
-          const glob = new Bun.Glob("**/*.json")
-          const results = await Array.fromAsync(
-            glob.scan({ cwd: targetDir, onlyFiles: true })
-          )
+          const results = await listJsonFiles(targetDir, { recursive: true })
           return results.map(x => x.slice(0, -5)).sort()
         } catch (error: unknown) {
           const err = error as { code?: string }


### PR DESCRIPTION
Because of problems when running the @core sdk from a node context we are moving away from the bun apis.