### PR TITLE
fix(cli): support clean eval output from tui

### DIFF
--- a/packages/awsesh/src/cli/args.test.ts
+++ b/packages/awsesh/src/cli/args.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeCliArgs } from "./args"
+
+describe("normalizeCliArgs", () => {
+  test("resolves direct positional invocation to session command", () => {
+    expect(normalizeCliArgs(["my-session", "account", "role"])).toEqual([
+      "session",
+      "my-session",
+      "account",
+      "role",
+    ])
+  })
+
+  test("keeps explicit commands unchanged", () => {
+    expect(normalizeCliArgs(["set", "my-session", "account", "role"])).toEqual([
+      "set",
+      "my-session",
+      "account",
+      "role",
+    ])
+  })
+
+  test("supports eval flag before positional session args", () => {
+    expect(normalizeCliArgs(["--eval", "my-session", "account", "role"])).toEqual([
+      "session",
+      "--eval",
+      "my-session",
+      "account",
+      "role",
+    ])
+  })
+
+  test("keeps bare eval flag for root tui command", () => {
+    expect(normalizeCliArgs(["--eval"])).toEqual(["--eval"])
+  })
+
+  test("ignores global option values when finding command token", () => {
+    expect(normalizeCliArgs(["--log-level", "DEBUG", "set", "my-session", "account"]))
+      .toEqual(["--log-level", "DEBUG", "set", "my-session", "account"])
+  })
+})

--- a/packages/awsesh/src/cli/args.ts
+++ b/packages/awsesh/src/cli/args.ts
@@ -1,0 +1,55 @@
+const commandNames = new Set([
+  "set",
+  "sessions",
+  "accounts",
+  "credentials",
+  "auth",
+  "whoami",
+  "migrate",
+  "config",
+  "data",
+  "session",
+  "help",
+  "version",
+])
+
+const optionsWithValue = new Set(["--log-level"])
+
+function firstCommandLikeToken(args: string[]): string | undefined {
+  let skipNext = false
+
+  for (const arg of args) {
+    if (skipNext) {
+      skipNext = false
+      continue
+    }
+
+    if (arg === "--") {
+      return undefined
+    }
+
+    if (optionsWithValue.has(arg)) {
+      skipNext = true
+      continue
+    }
+
+    if (arg.startsWith("-")) {
+      continue
+    }
+
+    return arg
+  }
+
+  return undefined
+}
+
+export function normalizeCliArgs(args: string[]): string[] {
+  const commandToken = firstCommandLikeToken(args)
+  if (!commandToken) return args
+
+  if (commandNames.has(commandToken)) {
+    return args
+  }
+
+  return ["session", ...args]
+}

--- a/packages/awsesh/src/cli/cmd/cli-integration.test.ts
+++ b/packages/awsesh/src/cli/cmd/cli-integration.test.ts
@@ -108,11 +108,23 @@ describe("CLI", () => {
       expect(exitCode).toBe(1);
       expect(stderr).toContain("No active credentials found for profile 'default'");
     });
+
+    test("keeps root behavior when --eval is also set", async () => {
+      const { stderr, exitCode } = await runCli(["--eval", "-b"], testEnv("root-browser-no-default-eval"));
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("No active credentials found for profile 'default'");
+    });
   });
 
   describe("direct session command", () => {
     test("resolves positional args to session command", async () => {
       const { stderr, exitCode } = await runCli(["missing-session", "account", "role"], testEnv("session-direct"));
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("SSO session 'missing-session' not found");
+    });
+
+    test("resolves positional args with --eval to session command", async () => {
+      const { stderr, exitCode } = await runCli(["--eval", "missing-session", "account", "role"], testEnv("session-direct-eval"));
       expect(exitCode).toBe(1);
       expect(stderr).toContain("SSO session 'missing-session' not found");
     });

--- a/packages/awsesh/src/cli/cmd/session.ts
+++ b/packages/awsesh/src/cli/cmd/session.ts
@@ -1,6 +1,7 @@
 import { cmd } from "./cmd"
 import { UI } from "../ui"
 import { getAwsesh } from "@/instance"
+import { printEvalEnvironment } from "@/util/styled-output"
 
 export const session = cmd({
   command: "session <ssoSession> <accountName> [roleName]",
@@ -131,11 +132,13 @@ export const session = cmd({
       })
 
       if (evalMode) {
-        console.log(`export AWS_REGION='${effectiveRegion}'`)
-        console.log(`export AWS_ACCESS_KEY_ID='${credentials.accessKeyId}'`)
-        console.log(`export AWS_SECRET_ACCESS_KEY='${credentials.secretAccessKey}'`)
-        console.log(`export AWS_SESSION_TOKEN='${credentials.sessionToken}'`)
-        console.log(`export AWS_SESSION_EXPIRATION='${credentials.expiration.toISOString()}'`)
+        printEvalEnvironment({
+          region: effectiveRegion,
+          accessKeyId: credentials.accessKeyId,
+          secretAccessKey: credentials.secretAccessKey,
+          sessionToken: credentials.sessionToken,
+          expiration: credentials.expiration.toISOString(),
+        })
       } else {
         UI.success("Credentials configured successfully!")
         UI.info(`Profile: ${result.profileName}`)

--- a/packages/awsesh/src/cli/cmd/set.ts
+++ b/packages/awsesh/src/cli/cmd/set.ts
@@ -4,6 +4,21 @@ import { UI } from "../ui"
 import { getAwsesh } from "@/instance"
 import { authenticate } from "./util/auth"
 import type { SSOSession, Account } from "@awsesh/core"
+import { printEvalEnvironment } from "@/util/styled-output"
+
+async function withStdoutRedirectedToStderr<T>(callback: () => Promise<T>): Promise<T> {
+  const originalWrite = process.stdout.write
+  const stderrWrite = process.stderr.write.bind(process.stderr)
+
+  process.stdout.write = ((...args: Parameters<typeof process.stderr.write>) =>
+    stderrWrite(...args)) as typeof process.stdout.write
+
+  try {
+    return await callback()
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}
 
 interface SetArgs {
   session?: string
@@ -80,14 +95,25 @@ export const set = cmd({
           return a.name.localeCompare(b.name)
         })
 
-        const result = await prompts.select({
-          message: "Select SSO session",
-          options: sortedSessions.map((s) => ({
-            label: s.name,
-            value: s.name,
-            hint: s.startUrl,
-          })),
-        })
+        const result = typedArgs.eval
+          ? await withStdoutRedirectedToStderr(() =>
+              prompts.select({
+                message: "Select SSO session",
+                options: sortedSessions.map((s) => ({
+                  label: s.name,
+                  value: s.name,
+                  hint: s.startUrl,
+                })),
+              })
+            )
+          : await prompts.select({
+              message: "Select SSO session",
+              options: sortedSessions.map((s) => ({
+                label: s.name,
+                value: s.name,
+                hint: s.startUrl,
+              })),
+            })
 
         if (prompts.isCancel(result)) {
           process.exit(0)
@@ -107,7 +133,7 @@ export const set = cmd({
 
     await awsesh.lastSession.save(session.name)
 
-    const token = await authenticate(awsesh, session)
+    const token = await authenticate(awsesh, session, { silent: typedArgs.eval })
     const accountList = await awsesh.sso.listAccounts(session, token.token)
 
     if (accountList.length === 0) {
@@ -126,14 +152,25 @@ export const set = cmd({
         return a.name.localeCompare(b.name)
       })
 
-      const result = await prompts.select({
-        message: "Select account",
-        options: sortedAccounts.map((a) => ({
-          label: a.name,
-          value: a.name,
-          hint: a.accountId,
-        })),
-      })
+      const result = typedArgs.eval
+        ? await withStdoutRedirectedToStderr(() =>
+            prompts.select({
+              message: "Select account",
+              options: sortedAccounts.map((a) => ({
+                label: a.name,
+                value: a.name,
+                hint: a.accountId,
+              })),
+            })
+          )
+        : await prompts.select({
+            message: "Select account",
+            options: sortedAccounts.map((a) => ({
+              label: a.name,
+              value: a.name,
+              hint: a.accountId,
+            })),
+          })
 
       if (prompts.isCancel(result)) {
         process.exit(0)
@@ -179,13 +216,23 @@ export const set = cmd({
             return a.localeCompare(b)
           })
 
-          const result = await prompts.select({
-            message: "Select role",
-            options: sortedRoles.map((r) => ({
-              label: r,
-              value: r,
-            })),
-          })
+          const result = typedArgs.eval
+            ? await withStdoutRedirectedToStderr(() =>
+                prompts.select({
+                  message: "Select role",
+                  options: sortedRoles.map((r) => ({
+                    label: r,
+                    value: r,
+                  })),
+                })
+              )
+            : await prompts.select({
+                message: "Select role",
+                options: sortedRoles.map((r) => ({
+                  label: r,
+                  value: r,
+                })),
+              })
 
           if (prompts.isCancel(result)) {
             process.exit(0)
@@ -219,8 +266,8 @@ export const set = cmd({
       return
     }
 
-    const spinner = prompts.spinner()
-    spinner.start("Getting credentials...")
+    const spinner = typedArgs.eval ? undefined : prompts.spinner()
+    spinner?.start("Getting credentials...")
 
     const creds = await awsesh.sso.getCredentials(
       session,
@@ -241,14 +288,16 @@ export const set = cmd({
       profileName: typedArgs.profile, // core looks up configured profile if undefined
     })
 
-    spinner.stop("Credentials set")
+    spinner?.stop("Credentials set")
 
     if (typedArgs.eval) {
-      UI.println(`export AWS_REGION='${effectiveRegion}'`)
-      UI.println(`export AWS_ACCESS_KEY_ID='${creds.accessKeyId}'`)
-      UI.println(`export AWS_SECRET_ACCESS_KEY='${creds.secretAccessKey}'`)
-      UI.println(`export AWS_SESSION_TOKEN='${creds.sessionToken}'`)
-      UI.println(`export AWS_SESSION_EXPIRATION='${creds.expiration.toISOString()}'`)
+      printEvalEnvironment({
+        region: effectiveRegion,
+        accessKeyId: creds.accessKeyId,
+        secretAccessKey: creds.secretAccessKey,
+        sessionToken: creds.sessionToken,
+        expiration: creds.expiration.toISOString(),
+      })
     } else {
       UI.println(UI.kv("Profile", result.profileName))
       UI.println(UI.kv("Region", effectiveRegion))

--- a/packages/awsesh/src/cli/cmd/tui/app.tsx
+++ b/packages/awsesh/src/cli/cmd/tui/app.tsx
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { render, useTerminalDimensions, useRenderer, useKeyboard } from "@opentui/solid";
 import { copyToClipboard } from "@/util/clipboard";
 import { Switch, Match } from "solid-js";
@@ -20,7 +21,7 @@ import { CredentialsScreen } from "./routes/credentials";
 import { Terminal } from "./util/terminal";
 import { getAwsesh } from "@/instance";
 import { printSessionInfo } from "@/util/styled-output";
-import { wereCredentialsSet } from "./context/session-state";
+import { wereCredentialsSet, getCapturedEvalEnvironment } from "./context/session-state";
 
 function App() {
   const route = useRoute();
@@ -87,7 +88,22 @@ function App() {
   );
 }
 
+async function captureEvalOutputIfRequested(): Promise<boolean> {
+  const captureFile = process.env.AWSESH_TUI_EVAL_CAPTURE_FILE;
+  if (!captureFile) return false;
+
+  if (wereCredentialsSet()) {
+    const captured = getCapturedEvalEnvironment();
+    if (captured) {
+      await fs.writeFile(captureFile, JSON.stringify(captured), "utf-8");
+    }
+  }
+
+  return true;
+}
+
 async function printLastSetCredential(): Promise<void> {
+  if (await captureEvalOutputIfRequested()) return;
   if (!wereCredentialsSet()) return
 
   const awsesh = getAwsesh();

--- a/packages/awsesh/src/cli/cmd/tui/context/aws.tsx
+++ b/packages/awsesh/src/cli/cmd/tui/context/aws.tsx
@@ -4,7 +4,7 @@ import { useAwsesh } from "./awsesh"
 import { Global } from "@/global"
 import { Log } from "@/util/log"
 import type { SSOSession, Account, SSOLoginInfo, ActiveCredential, TokenResult } from "@awsesh/core"
-import { markCredentialsSet } from "./session-state"
+import { markCredentialsSet, captureEvalEnvironment } from "./session-state"
 
 const log = Log.create({ service: "aws-context" })
 
@@ -314,6 +314,15 @@ export const { use: useAWS, provider: AWSProvider } = createSimpleContext({
 
           setActiveCredentials(await awsesh.activeCredentials.list())
           markCredentialsSet()
+          if (result.profileName === "default") {
+            captureEvalEnvironment({
+              region: targetRegion,
+              accessKeyId: credentials.accessKeyId,
+              secretAccessKey: credentials.secretAccessKey,
+              sessionToken: credentials.sessionToken,
+              expiration: credentials.expiration.toISOString(),
+            })
+          }
 
           return { expiration: result.expiration, profileName: result.profileName }
         } catch (e) {

--- a/packages/awsesh/src/cli/cmd/tui/context/session-state.ts
+++ b/packages/awsesh/src/cli/cmd/tui/context/session-state.ts
@@ -1,9 +1,27 @@
 let credentialsSetThisSession = false
 
+interface CapturedEvalEnvironment {
+  region: string
+  accessKeyId: string
+  secretAccessKey: string
+  sessionToken: string
+  expiration: string
+}
+
+let capturedEvalEnvironment: CapturedEvalEnvironment | undefined
+
 export function markCredentialsSet(): void {
   credentialsSetThisSession = true
 }
 
 export function wereCredentialsSet(): boolean {
   return credentialsSetThisSession
+}
+
+export function captureEvalEnvironment(environment: CapturedEvalEnvironment): void {
+  capturedEvalEnvironment = environment
+}
+
+export function getCapturedEvalEnvironment(): CapturedEvalEnvironment | undefined {
+  return capturedEvalEnvironment
 }

--- a/packages/awsesh/src/cli/cmd/tui/thread.ts
+++ b/packages/awsesh/src/cli/cmd/tui/thread.ts
@@ -1,5 +1,52 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { tmpdir } from "node:os"
+import { spawn } from "node:child_process"
 import { cmd } from "../cmd"
 import { openDefaultProfileInBrowser } from "../util/open-default-profile-browser"
+import { printEvalEnvironment } from "@/util/styled-output"
+
+interface EvalCapture {
+  region: string
+  accessKeyId: string
+  secretAccessKey: string
+  sessionToken: string
+  expiration: string
+}
+
+async function runTuiForEvalMode(): Promise<void> {
+  const captureFile = path.join(tmpdir(), `awsesh-eval-${process.pid}-${Date.now()}.json`)
+  const childArgs = process.argv.slice(1).filter((arg) => arg !== "--eval" && arg !== "-e")
+
+  const child = spawn(process.argv[0], childArgs, {
+    stdio: ["inherit", process.stderr, "inherit"],
+    env: {
+      ...process.env,
+      AWSESH_TUI_EVAL_CAPTURE_FILE: captureFile,
+    },
+  })
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.on("error", reject)
+    child.on("close", (code) => resolve(code ?? 1))
+  })
+
+  let capture: EvalCapture | undefined
+  try {
+    const raw = await fs.readFile(captureFile, "utf-8")
+    capture = JSON.parse(raw) as EvalCapture
+  } catch {}
+
+  await fs.rm(captureFile, { force: true })
+
+  if (exitCode !== 0) {
+    process.exit(exitCode)
+  }
+
+  if (capture) {
+    printEvalEnvironment(capture)
+  }
+}
 
 export const TuiCommand = cmd({
   command: "$0",
@@ -12,9 +59,14 @@ export const TuiCommand = cmd({
       default: false,
     }),
   handler: async (args) => {
-    const { browser } = args as { browser: boolean }
+    const { browser, eval: evalMode } = args as { browser: boolean; eval?: boolean }
     if (browser) {
       await openDefaultProfileInBrowser()
+      return
+    }
+
+    if (evalMode) {
+      await runTuiForEvalMode()
       return
     }
 

--- a/packages/awsesh/src/cli/cmd/util/auth.ts
+++ b/packages/awsesh/src/cli/cmd/util/auth.ts
@@ -34,8 +34,8 @@ export async function authenticate(
 
   await openBrowser(loginInfo.verificationUriComplete)
 
-  const spinner = prompts.spinner()
-  spinner.start("Waiting for authorization...")
+  const spinner = options?.silent ? undefined : prompts.spinner()
+  spinner?.start("Waiting for authorization...")
 
   let tokenResult: TokenResult | null = null
   while (!tokenResult) {
@@ -43,14 +43,14 @@ export async function authenticate(
       await Bun.sleep(loginInfo.interval * 1000)
       tokenResult = await awsesh.sso.pollForToken(session, loginInfo)
     } catch (error) {
-      spinner.stop()
+      spinner?.stop()
       throw error
     }
   }
 
   await awsesh.tokens.save(session.startUrl, tokenResult.token, tokenResult.expiresAt)
 
-  spinner.stop("Authenticated")
+  spinner?.stop("Authenticated")
 
   return {
     token: tokenResult.token,

--- a/packages/awsesh/src/index.ts
+++ b/packages/awsesh/src/index.ts
@@ -3,6 +3,7 @@ import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { Log } from "./util/log"
 import { UI } from "./cli/ui"
+import { normalizeCliArgs } from "./cli/args"
 
 import { auth } from "./cli/cmd/auth.js"
 import { whoami } from "./cli/cmd/whoami.js"
@@ -20,27 +21,7 @@ import { Installation } from "./installation"
 import { createCliRenderer } from "@opentui/core"
 
 const args = hideBin(process.argv)
-const commandNames = new Set([
-  "set",
-  "sessions",
-  "accounts",
-  "credentials",
-  "auth",
-  "whoami",
-  "migrate",
-  "config",
-  "data",
-  "session",
-  "help",
-  "version",
-])
-
-const usePositionalSession =
-  args.length > 0 &&
-  !args[0].startsWith("-") &&
-  !commandNames.has(args[0])
-
-const normalizedArgs = usePositionalSession ? ["session", ...args] : args
+const normalizedArgs = normalizeCliArgs(args)
 const showHelp = args.includes("--help") || args.includes("-h") || args[0] === "help"
 if (showHelp) {
   console.log(UI.logo())
@@ -64,6 +45,11 @@ const cli = yargs(normalizedArgs)
     describe: "log level",
     type: "string",
     choices: ["DEBUG", "INFO", "WARN", "ERROR"],
+  })
+  .option("eval", {
+    describe: "output environment variables for shell eval",
+    type: "boolean",
+    alias: "e",
   })
   .middleware(async (opts) => {
     await Log.init({

--- a/packages/awsesh/src/util/styled-output.test.ts
+++ b/packages/awsesh/src/util/styled-output.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
 import fs from "node:fs";
-import { printSessionInfo } from "./styled-output";
+import { printSessionInfo, printEvalEnvironment } from "./styled-output";
 
 describe("printSessionInfo", () => {
   let writeSync: ReturnType<typeof spyOn>;
@@ -103,5 +103,57 @@ describe("printSessionInfo", () => {
     });
 
     expect(capturedOutput).toContain("\x1b[2m");
+  });
+});
+
+describe("printEvalEnvironment", () => {
+  let writeSync: ReturnType<typeof spyOn>;
+  let capturedOutput: string;
+
+  beforeEach(() => {
+    capturedOutput = "";
+    writeSync = spyOn(fs, "writeSync").mockImplementation((fd: number, data: ArrayBufferView | string) => {
+      if (typeof data === "string") {
+        capturedOutput = data;
+        return data.length;
+      }
+
+      capturedOutput = new TextDecoder().decode(data);
+      return data.byteLength;
+    });
+  });
+
+  afterEach(() => {
+    writeSync.mockRestore();
+  });
+
+  test("prints shell export statements", () => {
+    printEvalEnvironment({
+      region: "eu-north-1",
+      accessKeyId: "AKIA123",
+      secretAccessKey: "secret",
+      sessionToken: "token",
+      expiration: "2026-06-12T15:18:54.000Z",
+    });
+
+    expect(capturedOutput).toContain("export AWS_REGION='eu-north-1'");
+    expect(capturedOutput).toContain("export AWS_ACCESS_KEY_ID='AKIA123'");
+    expect(capturedOutput).toContain("export AWS_SECRET_ACCESS_KEY='secret'");
+    expect(capturedOutput).toContain("export AWS_SESSION_TOKEN='token'");
+    expect(capturedOutput).toContain("export AWS_SESSION_EXPIRATION='2026-06-12T15:18:54.000Z'");
+  });
+
+  test("escapes single quotes for shell safety", () => {
+    printEvalEnvironment({
+      region: "eu-north-1",
+      accessKeyId: "AKIA'123",
+      secretAccessKey: "sec'ret",
+      sessionToken: "tok'en",
+      expiration: "2026-06-12T15:18:54.000Z",
+    });
+
+    expect(capturedOutput).toContain("export AWS_ACCESS_KEY_ID='AKIA'\"'\"'123'");
+    expect(capturedOutput).toContain("export AWS_SECRET_ACCESS_KEY='sec'\"'\"'ret'");
+    expect(capturedOutput).toContain("export AWS_SESSION_TOKEN='tok'\"'\"'en'");
   });
 });

--- a/packages/awsesh/src/util/styled-output.ts
+++ b/packages/awsesh/src/util/styled-output.ts
@@ -13,6 +13,18 @@ export interface SessionInfo {
   profileName?: string
 }
 
+export interface EvalEnvironment {
+  region: string
+  accessKeyId: string
+  secretAccessKey: string
+  sessionToken: string
+  expiration: string
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
 export function printSessionInfo(info: SessionInfo): void {
   const lines: string[] = [""]
   lines.push(`${GRAY}Session${RESET}  ${info.sessionName}`)
@@ -23,6 +35,18 @@ export function printSessionInfo(info: SessionInfo): void {
     lines.push(`${GRAY}Profile${RESET}  ${info.profileName}`)
   }
   lines.push("")
+
+  fs.writeSync(1, `${lines.join("\n")}\n`)
+}
+
+export function printEvalEnvironment(environment: EvalEnvironment): void {
+  const lines = [
+    `export AWS_REGION=${shellQuote(environment.region)}`,
+    `export AWS_ACCESS_KEY_ID=${shellQuote(environment.accessKeyId)}`,
+    `export AWS_SECRET_ACCESS_KEY=${shellQuote(environment.secretAccessKey)}`,
+    `export AWS_SESSION_TOKEN=${shellQuote(environment.sessionToken)}`,
+    `export AWS_SESSION_EXPIRATION=${shellQuote(environment.expiration)}`,
+  ]
 
   fs.writeSync(1, `${lines.join("\n")}\n`)
 }


### PR DESCRIPTION
## Why

`--eval` behavior was inconsistent and broke shell-wrapper usage:

- `awsesh --eval` did not behave like root TUI + eval output
- TUI output/noise could leak into stdout and break `eval "$(awsesh --eval ...)"` flows
- export formatting was duplicated across commands

## What changed

- Added global `--eval` handling that works with root command parsing.
- Kept root behavior for `awsesh --eval`:
  - launches TUI
  - suppresses TUI noise from stdout
  - prints only `export ...` lines on stdout when exiting (if default creds were set during that session)
- Preserved direct command behavior:
  - `awsesh set --eval` prints clean exports
  - `awsesh <session> <account> <role> --eval` still routes through `session` command and prints exports
- Consolidated export printing in a shared formatter (`printEvalEnvironment`) with shell-safe quoting.
- Added argument normalization utility and tests for flag/positional routing.

## Tests

Ran and passing:

- `bun run --filter awsesh typecheck`
- `bun test packages/awsesh/src/cli/args.test.ts packages/awsesh/src/util/styled-output.test.ts packages/awsesh/src/cli/cmd/cli-integration.test.ts`

Also verified behavior manually for stream separation in root eval mode (stdout stays clean during TUI).

## Result

Shell integration now works as expected for both TUI and direct command flows, and `--eval` output is safe/clean for `eval` wrappers.