### PR TITLE
fix(cli): handle bunfs eval relaunch in tui

### DIFF
--- a/packages/awsesh/src/cli/cmd/tui/eval-relaunch.test.ts
+++ b/packages/awsesh/src/cli/cmd/tui/eval-relaunch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { removeEvalFlags, resolveEvalRelaunchCommand } from "./eval-relaunch"
+
+describe("removeEvalFlags", () => {
+  test("removes both eval flag variants", () => {
+    expect(removeEvalFlags(["--eval", "set", "-e", "foo"])).toEqual(["set", "foo"])
+  })
+})
+
+describe("resolveEvalRelaunchCommand", () => {
+  test("uses awsesh command when running from bunfs", () => {
+    const result = resolveEvalRelaunchCommand([
+      "/opt/homebrew/bin/bun",
+      "/$bunfs/root/src/index.js",
+      "--eval",
+      "--log-level",
+      "DEBUG",
+    ])
+
+    expect(result).toEqual({
+      command: "awsesh",
+      args: ["--log-level", "DEBUG"],
+    })
+  })
+
+  test("relaunches via current runtime for normal script paths", () => {
+    const result = resolveEvalRelaunchCommand([
+      "/opt/homebrew/bin/bun",
+      "/Users/dev/awsesh/src/index.ts",
+      "--eval",
+      "--browser",
+    ])
+
+    expect(result).toEqual({
+      command: "/opt/homebrew/bin/bun",
+      args: ["/Users/dev/awsesh/src/index.ts", "--browser"],
+    })
+  })
+})

--- a/packages/awsesh/src/cli/cmd/tui/eval-relaunch.ts
+++ b/packages/awsesh/src/cli/cmd/tui/eval-relaunch.ts
@@ -1,0 +1,23 @@
+export interface RelaunchCommand {
+  command: string
+  args: string[]
+}
+
+export function removeEvalFlags(args: string[]): string[] {
+  return args.filter((arg) => arg !== "--eval" && arg !== "-e")
+}
+
+export function resolveEvalRelaunchCommand(argv: string[]): RelaunchCommand {
+  const scriptPath = argv[1] ?? ""
+  if (scriptPath.startsWith("/$bunfs/")) {
+    return {
+      command: "awsesh",
+      args: removeEvalFlags(argv.slice(2)),
+    }
+  }
+
+  return {
+    command: argv[0],
+    args: removeEvalFlags(argv.slice(1)),
+  }
+}

--- a/packages/awsesh/src/cli/cmd/tui/thread.ts
+++ b/packages/awsesh/src/cli/cmd/tui/thread.ts
@@ -5,6 +5,7 @@ import { spawn } from "node:child_process"
 import { cmd } from "../cmd"
 import { openDefaultProfileInBrowser } from "../util/open-default-profile-browser"
 import { printEvalEnvironment } from "@/util/styled-output"
+import { resolveEvalRelaunchCommand, type RelaunchCommand } from "./eval-relaunch"
 
 interface EvalCapture {
   region: string
@@ -14,11 +15,8 @@ interface EvalCapture {
   expiration: string
 }
 
-async function runTuiForEvalMode(): Promise<void> {
-  const captureFile = path.join(tmpdir(), `awsesh-eval-${process.pid}-${Date.now()}.json`)
-  const childArgs = process.argv.slice(1).filter((arg) => arg !== "--eval" && arg !== "-e")
-
-  const child = spawn(process.argv[0], childArgs, {
+async function runChild(command: RelaunchCommand, captureFile: string): Promise<number> {
+  const child = spawn(command.command, command.args, {
     stdio: ["inherit", process.stderr, "inherit"],
     env: {
       ...process.env,
@@ -26,10 +24,33 @@ async function runTuiForEvalMode(): Promise<void> {
     },
   })
 
-  const exitCode = await new Promise<number>((resolve, reject) => {
+  return await new Promise<number>((resolve, reject) => {
     child.on("error", reject)
     child.on("close", (code) => resolve(code ?? 1))
   })
+}
+
+async function runTuiForEvalMode(): Promise<void> {
+  const captureFile = path.join(tmpdir(), `awsesh-eval-${process.pid}-${Date.now()}.json`)
+
+  const primaryCommand = resolveEvalRelaunchCommand(process.argv)
+  let exitCode: number
+
+  try {
+    exitCode = await runChild(primaryCommand, captureFile)
+  } catch (error) {
+    const fallbackAllowed =
+      primaryCommand.command === "awsesh" &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+
+    if (!fallbackAllowed) {
+      throw error
+    }
+
+    throw new Error(
+      "Failed to relaunch awsesh in eval mode: command 'awsesh' was not found in PATH. Ensure awsesh is installed and available in your shell.",
+    )
+  }
 
   let capture: EvalCapture | undefined
   try {


### PR DESCRIPTION
## What

Fixes `awsesh --eval` relaunch behavior in TUI mode when running from Bun-installed virtual paths like `/$bunfs/root/src/index.js`.

## Why

Using this shell function:

```zsh
sesh() {
  eval "$(command awsesh --eval "$@")"
}
```

could fail with:

```text
error: Module not found "/$bunfs/root/src/index.js"
```

because eval mode relaunched the process using `process.argv[0]` + `process.argv[1...]`, and in installed Bun contexts `argv[1]` may point to Bun’s virtual FS path, which is not valid in a fresh subprocess.

## Changes

- Added eval relaunch resolver utilities:
  - `packages/awsesh/src/cli/cmd/tui/eval-relaunch.ts`
- Updated TUI eval relaunch flow:
  - `packages/awsesh/src/cli/cmd/tui/thread.ts`
  - For `/$bunfs/...` script paths, relaunches as:
    - `awsesh <args-without---eval>`
  - For normal script paths, preserves existing runtime/script relaunch behavior.
- Improved fallback behavior:
  - If `awsesh` relaunch is selected but `awsesh` is not on `PATH` (`ENOENT`), now throws a clear explicit error instead of retrying a likely-invalid virtual script path.

## Tests

- Added unit tests:
  - `packages/awsesh/src/cli/cmd/tui/eval-relaunch.test.ts`
  - Covers:
    - eval flag stripping
    - bunfs path -> `awsesh` relaunch
    - normal script path -> runtime/script relaunch
- Validation:
  - `bun test packages/awsesh/src/cli/cmd/tui/eval-relaunch.test.ts packages/awsesh/src/cli/cmd/cli-integration.test.ts`
  - `bun run --filter awsesh typecheck`