### PR TITLE
feat(cli): export AWSESH metadata in eval mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ function sesh
 end
 ```
 
+When you run `awsesh --eval` (or `sesh` in the examples above), awsesh exports AWS credentials plus session metadata:
+
+- `AWSESH_ACCOUNT_ID`
+- `AWSESH_ACCOUNT_NAME`
+- `AWSESH_ROLE_NAME`
+- `AWSESH_SESSION_NAME`
+- `AWS_REGION`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_SESSION_TOKEN`
+- `AWS_SESSION_EXPIRATION`
+
 ## SDK
 
 The core functionality is available as a standalone SDK for building your own AWS SSO tools.

--- a/packages/awsesh/src/cli/cmd/session.ts
+++ b/packages/awsesh/src/cli/cmd/session.ts
@@ -133,6 +133,10 @@ export const session = cmd({
 
       if (evalMode) {
         printEvalEnvironment({
+          accountId: account.accountId,
+          accountName: account.name,
+          roleName: selectedRole,
+          sessionName: ssoSession,
           region: effectiveRegion,
           accessKeyId: credentials.accessKeyId,
           secretAccessKey: credentials.secretAccessKey,

--- a/packages/awsesh/src/cli/cmd/set.ts
+++ b/packages/awsesh/src/cli/cmd/set.ts
@@ -292,6 +292,10 @@ export const set = cmd({
 
     if (typedArgs.eval) {
       printEvalEnvironment({
+        accountId: account.accountId,
+        accountName: account.name,
+        roleName: selectedRole,
+        sessionName: session.name,
         region: effectiveRegion,
         accessKeyId: creds.accessKeyId,
         secretAccessKey: creds.secretAccessKey,

--- a/packages/awsesh/src/cli/cmd/tui/context/aws.tsx
+++ b/packages/awsesh/src/cli/cmd/tui/context/aws.tsx
@@ -316,6 +316,10 @@ export const { use: useAWS, provider: AWSProvider } = createSimpleContext({
           markCredentialsSet()
           if (result.profileName === "default") {
             captureEvalEnvironment({
+              accountId,
+              accountName,
+              roleName,
+              sessionName: session.name,
               region: targetRegion,
               accessKeyId: credentials.accessKeyId,
               secretAccessKey: credentials.secretAccessKey,

--- a/packages/awsesh/src/cli/cmd/tui/context/session-state.ts
+++ b/packages/awsesh/src/cli/cmd/tui/context/session-state.ts
@@ -1,6 +1,10 @@
 let credentialsSetThisSession = false
 
 interface CapturedEvalEnvironment {
+  accountId: string
+  accountName: string
+  roleName: string
+  sessionName: string
   region: string
   accessKeyId: string
   secretAccessKey: string

--- a/packages/awsesh/src/cli/cmd/tui/thread.ts
+++ b/packages/awsesh/src/cli/cmd/tui/thread.ts
@@ -7,6 +7,10 @@ import { openDefaultProfileInBrowser } from "../util/open-default-profile-browse
 import { printEvalEnvironment } from "@/util/styled-output"
 
 interface EvalCapture {
+  accountId: string
+  accountName: string
+  roleName: string
+  sessionName: string
   region: string
   accessKeyId: string
   secretAccessKey: string

--- a/packages/awsesh/src/util/styled-output.test.ts
+++ b/packages/awsesh/src/util/styled-output.test.ts
@@ -129,6 +129,10 @@ describe("printEvalEnvironment", () => {
 
   test("prints shell export statements", () => {
     printEvalEnvironment({
+      accountId: "123456789012",
+      accountName: "Production",
+      roleName: "Admin",
+      sessionName: "acme",
       region: "eu-north-1",
       accessKeyId: "AKIA123",
       secretAccessKey: "secret",
@@ -136,6 +140,10 @@ describe("printEvalEnvironment", () => {
       expiration: "2026-06-12T15:18:54.000Z",
     });
 
+    expect(capturedOutput).toContain("export AWSESH_ACCOUNT_ID='123456789012'");
+    expect(capturedOutput).toContain("export AWSESH_ACCOUNT_NAME='Production'");
+    expect(capturedOutput).toContain("export AWSESH_ROLE_NAME='Admin'");
+    expect(capturedOutput).toContain("export AWSESH_SESSION_NAME='acme'");
     expect(capturedOutput).toContain("export AWS_REGION='eu-north-1'");
     expect(capturedOutput).toContain("export AWS_ACCESS_KEY_ID='AKIA123'");
     expect(capturedOutput).toContain("export AWS_SECRET_ACCESS_KEY='secret'");
@@ -145,6 +153,10 @@ describe("printEvalEnvironment", () => {
 
   test("escapes single quotes for shell safety", () => {
     printEvalEnvironment({
+      accountId: "123456789012",
+      accountName: "prod'o",
+      roleName: "Admin'Role",
+      sessionName: "acm'e",
       region: "eu-north-1",
       accessKeyId: "AKIA'123",
       secretAccessKey: "sec'ret",
@@ -152,6 +164,9 @@ describe("printEvalEnvironment", () => {
       expiration: "2026-06-12T15:18:54.000Z",
     });
 
+    expect(capturedOutput).toContain("export AWSESH_ACCOUNT_NAME='prod'\"'\"'o'");
+    expect(capturedOutput).toContain("export AWSESH_ROLE_NAME='Admin'\"'\"'Role'");
+    expect(capturedOutput).toContain("export AWSESH_SESSION_NAME='acm'\"'\"'e'");
     expect(capturedOutput).toContain("export AWS_ACCESS_KEY_ID='AKIA'\"'\"'123'");
     expect(capturedOutput).toContain("export AWS_SECRET_ACCESS_KEY='sec'\"'\"'ret'");
     expect(capturedOutput).toContain("export AWS_SESSION_TOKEN='tok'\"'\"'en'");

--- a/packages/awsesh/src/util/styled-output.ts
+++ b/packages/awsesh/src/util/styled-output.ts
@@ -14,6 +14,10 @@ export interface SessionInfo {
 }
 
 export interface EvalEnvironment {
+  accountId: string
+  accountName: string
+  roleName: string
+  sessionName: string
   region: string
   accessKeyId: string
   secretAccessKey: string
@@ -41,6 +45,10 @@ export function printSessionInfo(info: SessionInfo): void {
 
 export function printEvalEnvironment(environment: EvalEnvironment): void {
   const lines = [
+    `export AWSESH_ACCOUNT_ID=${shellQuote(environment.accountId)}`,
+    `export AWSESH_ACCOUNT_NAME=${shellQuote(environment.accountName)}`,
+    `export AWSESH_ROLE_NAME=${shellQuote(environment.roleName)}`,
+    `export AWSESH_SESSION_NAME=${shellQuote(environment.sessionName)}`,
     `export AWS_REGION=${shellQuote(environment.region)}`,
     `export AWS_ACCESS_KEY_ID=${shellQuote(environment.accessKeyId)}`,
     `export AWS_SECRET_ACCESS_KEY=${shellQuote(environment.secretAccessKey)}`,


### PR DESCRIPTION
## What
- export AWSESH metadata variables in eval output:
  - AWSESH_ACCOUNT_ID
  - AWSESH_ACCOUNT_NAME
  - AWSESH_ROLE_NAME
  - AWSESH_SESSION_NAME
- include the metadata in all eval code paths (set, session, and TUI eval capture flow)
- extend eval output tests to cover new exports and shell escaping
- document exported eval variables in README shell integration section

## Why
This makes prompt integrations (e.g. Starship) straightforward without parsing awsesh storage files.

## Validation
- bun test packages/awsesh/src/util/styled-output.test.ts
- bun run --filter awsesh typecheck