### PR TITLE
feat(cli): non-fatal browser opening with auto-detect and --no-browser

### DIFF
--- a/packages/awsesh/src/cli/cmd/auth.ts
+++ b/packages/awsesh/src/cli/cmd/auth.ts
@@ -9,6 +9,7 @@ interface AuthArgs {
   session?: string
   list?: boolean
   delete?: string
+  browser?: boolean
 }
 
 export const auth = cmd({
@@ -30,6 +31,11 @@ export const auth = cmd({
         type: "string",
         alias: "d",
         describe: "Delete an SSO session by name",
+      })
+      .option("browser", {
+        type: "boolean",
+        describe: "Open the verification URL in a browser (use --no-browser on headless hosts)",
+        default: true,
       }),
   handler: async (args) => {
     const typedArgs = args as AuthArgs
@@ -98,8 +104,10 @@ export const auth = cmd({
       UI.info("Verification code copied to clipboard!\n")
     }
 
-    await openBrowser(loginInfo.verificationUriComplete)
-    UI.info("Opening browser...\n")
+    const opened = typedArgs.browser === false
+      ? false
+      : await openBrowser(loginInfo.verificationUriComplete)
+    UI.info(opened ? "Opening browser...\n" : "Visit the URL above to authorize.\n")
 
     UI.info("Waiting for authorization...")
     

--- a/packages/awsesh/src/cli/cmd/set.ts
+++ b/packages/awsesh/src/cli/cmd/set.ts
@@ -259,10 +259,14 @@ export const set = cmd({
 
     if (typedArgs.browser) {
       const url = awsesh.sso.getAccountUrl(session, account.accountId, token.token, selectedRole)
-      prompts.log.info("Opening AWS console in browser...")
       const { openBrowser } = await import("@/util/browser")
-      await openBrowser(url)
-      prompts.log.success("Browser opened")
+      const opened = await openBrowser(url)
+      if (opened) {
+        prompts.log.success("Opened AWS console in browser")
+      } else {
+        prompts.log.info("Could not open a browser — open this URL manually:")
+        UI.println(`  ${url}`)
+      }
       return
     }
 

--- a/packages/awsesh/src/cli/cmd/util/auth.ts
+++ b/packages/awsesh/src/cli/cmd/util/auth.ts
@@ -6,7 +6,7 @@ import { copyToClipboard } from "@/util/clipboard"
 export async function authenticate(
   awsesh: Awsesh,
   session: SSOSession,
-  options?: { silent?: boolean }
+  options?: { silent?: boolean; noBrowser?: boolean }
 ): Promise<TokenCache> {
   const existingToken = await awsesh.tokens.get(session.startUrl)
   if (existingToken) {
@@ -32,7 +32,10 @@ export async function authenticate(
     prompts.log.info("Verification code copied to clipboard")
   }
 
-  await openBrowser(loginInfo.verificationUriComplete)
+  const opened = options?.noBrowser ? false : await openBrowser(loginInfo.verificationUriComplete)
+  if (!opened && !options?.silent) {
+    prompts.log.info("Could not open a browser — visit the URL above to authorize.")
+  }
 
   const spinner = options?.silent ? undefined : prompts.spinner()
   spinner?.start("Waiting for authorization...")

--- a/packages/awsesh/src/util/browser.test.ts
+++ b/packages/awsesh/src/util/browser.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import { browserAvailable } from "./browser"
+
+describe("browserAvailable", () => {
+  const saved = {
+    AWSESH_NO_BROWSER: process.env.AWSESH_NO_BROWSER,
+    CI: process.env.CI,
+    DISPLAY: process.env.DISPLAY,
+    WAYLAND_DISPLAY: process.env.WAYLAND_DISPLAY,
+  }
+
+  function set(key: keyof typeof saved, value?: string) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      set(key as keyof typeof saved, value)
+    }
+  })
+
+  test("opts out when AWSESH_NO_BROWSER is set", () => {
+    set("AWSESH_NO_BROWSER", "1")
+    set("DISPLAY", ":0")
+    expect(browserAvailable()).toBe(false)
+  })
+
+  test("opts out in CI", () => {
+    set("AWSESH_NO_BROWSER", undefined)
+    set("CI", "true")
+    set("DISPLAY", ":0")
+    expect(browserAvailable()).toBe(false)
+  })
+
+  test("is false on headless linux (no display)", () => {
+    if (process.platform !== "linux") return
+    set("AWSESH_NO_BROWSER", undefined)
+    set("CI", undefined)
+    set("DISPLAY", undefined)
+    set("WAYLAND_DISPLAY", undefined)
+    expect(browserAvailable()).toBe(false)
+  })
+
+  test("is true on linux with a display", () => {
+    if (process.platform !== "linux") return
+    set("AWSESH_NO_BROWSER", undefined)
+    set("CI", undefined)
+    set("DISPLAY", ":0")
+    expect(browserAvailable()).toBe(true)
+  })
+})

--- a/packages/awsesh/src/util/browser.ts
+++ b/packages/awsesh/src/util/browser.ts
@@ -1,9 +1,38 @@
 import open from "open"
 
-export async function openBrowser(url: string): Promise<void> {
+/**
+ * Check whether a browser can plausibly be opened on this machine.
+ *
+ * Returns false on headless hosts (no display server on Linux), in CI, or when
+ * the user opts out via AWSESH_NO_BROWSER. This lets callers degrade to printing
+ * the URL instead of crashing when there is no `xdg-open`/display available.
+ */
+export function browserAvailable(): boolean {
+  if (process.env.AWSESH_NO_BROWSER) return false
+  if (process.env.CI) return false
+
+  if (process.platform === "linux") {
+    return !!(process.env.DISPLAY || process.env.WAYLAND_DISPLAY)
+  }
+
+  // macOS `open` and Windows `start` are always present.
+  return true
+}
+
+/**
+ * Attempt to open `url` in the default browser.
+ *
+ * Never throws: returns true if a browser was launched, false if none is
+ * available or the launch failed. Callers should fall back to printing the URL
+ * when this returns false.
+ */
+export async function openBrowser(url: string): Promise<boolean> {
+  if (!browserAvailable()) return false
+
   try {
     await open(url)
-  } catch (error) {
-    throw new Error(`Failed to open browser: ${error}`)
+    return true
+  } catch {
+    return false
   }
 }


### PR DESCRIPTION
## Summary
Opening a browser previously **threw** when no browser/display was available, crashing `auth` and `set --browser` on headless hosts (SSH sessions, CI, containers). This makes browser opening best-effort and adds an explicit opt-out.

## Changes
- `openBrowser()` now returns `boolean` and never throws.
- New `browserAvailable()` skips the attempt when there's no display (Linux `DISPLAY`/`WAYLAND_DISPLAY`), in `CI`, or when `AWSESH_NO_BROWSER` is set.
- `auth` gains `--browser`/`--no-browser` (default on); prints the verification URL as a fallback.
- `set --browser` prints the console URL instead of erroring when no browser can be opened.
- Adds `browser.test.ts` covering headless detection.

## Testing
- `bun run typecheck` ✅
- `bun test` ✅ 207 pass / 0 fail
- Smoke: `auth --help` shows `--no-browser`; no crash on headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)