### PR TITLE
feat(cli): --json output for whoami/set and NO_COLOR support

### DIFF
--- a/packages/awsesh/src/cli/cmd/set.ts
+++ b/packages/awsesh/src/cli/cmd/set.ts
@@ -28,6 +28,7 @@ interface SetArgs {
   region?: string
   eval?: boolean
   browser?: boolean
+  json?: boolean
 }
 
 export const set = cmd({
@@ -68,10 +69,20 @@ export const set = cmd({
         alias: "b",
         describe: "Open AWS console in browser instead of setting credentials",
         default: false,
+      })
+      .option("json", {
+        type: "boolean",
+        alias: "j",
+        describe: "Output the resulting credential as JSON",
+        default: false,
       }),
   handler: async (args) => {
     const typedArgs = args as SetArgs
     const awsesh = getAwsesh()
+
+    // Both --eval and --json must keep stdout clean for machine consumption, so
+    // prompts/spinners are redirected to stderr or suppressed in either mode.
+    const quiet = typedArgs.eval || typedArgs.json
 
     const sessionList = await awsesh.sessions.list()
     if (sessionList.length === 0) {
@@ -95,7 +106,7 @@ export const set = cmd({
           return a.name.localeCompare(b.name)
         })
 
-        const result = typedArgs.eval
+        const result = quiet
           ? await withStdoutRedirectedToStderr(() =>
               prompts.select({
                 message: "Select SSO session",
@@ -133,7 +144,7 @@ export const set = cmd({
 
     await awsesh.lastSession.save(session.name)
 
-    const token = await authenticate(awsesh, session, { silent: typedArgs.eval })
+    const token = await authenticate(awsesh, session, { silent: quiet })
     const accountList = await awsesh.sso.listAccounts(session, token.token)
 
     if (accountList.length === 0) {
@@ -152,7 +163,7 @@ export const set = cmd({
         return a.name.localeCompare(b.name)
       })
 
-      const result = typedArgs.eval
+      const result = quiet
         ? await withStdoutRedirectedToStderr(() =>
             prompts.select({
               message: "Select account",
@@ -216,7 +227,7 @@ export const set = cmd({
             return a.localeCompare(b)
           })
 
-          const result = typedArgs.eval
+          const result = quiet
             ? await withStdoutRedirectedToStderr(() =>
                 prompts.select({
                   message: "Select role",
@@ -266,7 +277,7 @@ export const set = cmd({
       return
     }
 
-    const spinner = typedArgs.eval ? undefined : prompts.spinner()
+    const spinner = quiet ? undefined : prompts.spinner()
     spinner?.start("Getting credentials...")
 
     const creds = await awsesh.sso.getCredentials(
@@ -302,6 +313,22 @@ export const set = cmd({
         sessionToken: creds.sessionToken,
         expiration: creds.expiration.toISOString(),
       })
+    } else if (typedArgs.json) {
+      UI.println(
+        JSON.stringify(
+          {
+            profile: result.profileName,
+            region: effectiveRegion,
+            accountId: account.accountId,
+            accountName: account.name,
+            roleName: selectedRole,
+            sessionName: session.name,
+            expiration: result.expiration.toISOString(),
+          },
+          null,
+          2
+        )
+      )
     } else {
       UI.println(UI.kv("Profile", result.profileName))
       UI.println(UI.kv("Region", effectiveRegion))

--- a/packages/awsesh/src/cli/cmd/util/auth.ts
+++ b/packages/awsesh/src/cli/cmd/util/auth.ts
@@ -2,6 +2,7 @@ import * as prompts from "@clack/prompts"
 import type { Awsesh, SSOSession, TokenCache, TokenResult } from "@awsesh/core"
 import { openBrowser } from "@/util/browser"
 import { copyToClipboard } from "@/util/clipboard"
+import { colorEnabled } from "@/util/color"
 
 export async function authenticate(
   awsesh: Awsesh,
@@ -20,10 +21,12 @@ export async function authenticate(
 
   const loginInfo = await awsesh.sso.startLogin(session)
 
+  const gray = colorEnabled() ? "\x1b[90m" : ""
+  const reset = colorEnabled() ? "\x1b[0m" : ""
   if (!options?.silent) {
     console.log()
-    console.log(`  \x1b[90mURL:\x1b[0m  ${loginInfo.verificationUriComplete}`)
-    console.log(`  \x1b[90mCode:\x1b[0m ${loginInfo.userCode}`)
+    console.log(`  ${gray}URL:${reset}  ${loginInfo.verificationUriComplete}`)
+    console.log(`  ${gray}Code:${reset} ${loginInfo.userCode}`)
     console.log()
   }
 

--- a/packages/awsesh/src/cli/cmd/whoami.ts
+++ b/packages/awsesh/src/cli/cmd/whoami.ts
@@ -6,24 +6,55 @@ import { printSessionInfo } from "@/util/styled-output"
 export const whoami = cmd({
   command: "whoami",
   describe: "Show current AWS identity",
-  builder: (yargs) => yargs,
-  handler: async () => {
+  builder: (yargs) =>
+    yargs.option("json", {
+      type: "boolean",
+      alias: "j",
+      describe: "Output as JSON",
+      default: false,
+    }),
+  handler: async (args) => {
+    const { json } = args as { json: boolean }
     const awsesh = getAwsesh()
     const lastSet = await awsesh.lastSetCredential.get()
 
     if (!lastSet) {
-      UI.info("No AWS credentials currently configured.")
-      UI.info("Run 'awsesh' to configure your AWS credentials.")
+      if (json) {
+        UI.println(JSON.stringify(null))
+      } else {
+        UI.info("No AWS credentials currently configured.")
+        UI.info("Run 'awsesh' to configure your AWS credentials.")
+      }
       return
     }
 
     const session = await awsesh.sessions.get(lastSet.sessionName)
+    const region = lastSet.region ?? session?.defaultRegion ?? "unknown"
+
+    if (json) {
+      UI.println(
+        JSON.stringify(
+          {
+            sessionName: lastSet.sessionName,
+            accountName: lastSet.accountName,
+            accountId: lastSet.accountId,
+            roleName: lastSet.roleName,
+            region,
+            profileName: lastSet.profileName,
+          },
+          null,
+          2
+        )
+      )
+      return
+    }
+
     printSessionInfo({
       sessionName: lastSet.sessionName,
       accountName: lastSet.accountName,
       accountId: lastSet.accountId,
       roleName: lastSet.roleName,
-      region: lastSet.region ?? session?.defaultRegion ?? "unknown",
+      region,
       profileName: lastSet.profileName,
     })
   },

--- a/packages/awsesh/src/cli/ui.ts
+++ b/packages/awsesh/src/cli/ui.ts
@@ -1,3 +1,5 @@
+import { colorEnabled } from "@/util/color"
+
 export namespace UI {
   export const Style = {
     reset: "\x1b[0m",
@@ -10,6 +12,12 @@ export namespace UI {
     cyan: "\x1b[36m",
   }
 
+  // Wrap `text` in `code`…reset, but only when color is enabled. When piped or
+  // NO_COLOR is set this returns the bare text so captured output stays plain.
+  function paint(code: string, text: string): string {
+    return colorEnabled() ? `${code}${text}${Style.reset}` : text
+  }
+
   export function print(message: string) {
     process.stdout.write(message)
   }
@@ -19,43 +27,43 @@ export namespace UI {
   }
 
   export function error(message: string) {
-    console.error(`${Style.red}${message}${Style.reset}`)
+    console.error(paint(Style.red, message))
   }
 
   export function success(message: string) {
-    println(`${Style.green}${message}${Style.reset}`)
+    println(paint(Style.green, message))
   }
 
   export function info(message: string) {
-    println(`${Style.blue}${message}${Style.reset}`)
+    println(paint(Style.blue, message))
   }
 
   export function warn(message: string) {
-    println(`${Style.yellow}${message}${Style.reset}`)
+    println(paint(Style.yellow, message))
   }
 
   export function dim(text: string): string {
-    return `${Style.dim}${text}${Style.reset}`
+    return paint(Style.dim, text)
   }
 
   export function cyan(text: string): string {
-    return `${Style.cyan}${text}${Style.reset}`
+    return paint(Style.cyan, text)
   }
 
   export function green(text: string): string {
-    return `${Style.green}${text}${Style.reset}`
+    return paint(Style.green, text)
   }
 
   export function yellow(text: string): string {
-    return `${Style.yellow}${text}${Style.reset}`
+    return paint(Style.yellow, text)
   }
 
   export function red(text: string): string {
-    return `${Style.red}${text}${Style.reset}`
+    return paint(Style.red, text)
   }
 
   export function bold(text: string): string {
-    return `${Style.bold}${text}${Style.reset}`
+    return paint(Style.bold, text)
   }
 
   export function kv(key: string, value: string, indent = 2): string {
@@ -79,9 +87,10 @@ export namespace UI {
   }
 
 export function logo(): string {
-    const c = Style.cyan
-    const g = Style.dim
-    const r = Style.reset
+    const color = colorEnabled()
+    const c = color ? Style.cyan : ""
+    const g = color ? Style.dim : ""
+    const r = color ? Style.reset : ""
     const p = "\u00A0"
 
     return [

--- a/packages/awsesh/src/util/color.ts
+++ b/packages/awsesh/src/util/color.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether ANSI color/styling should be emitted.
+ *
+ * Honors the NO_COLOR convention (https://no-color.org): if NO_COLOR is present
+ * with any value, color is disabled. FORCE_COLOR overrides and forces it on
+ * (useful for tests and for piping into pagers that understand ANSI). Otherwise
+ * color is only emitted when stdout is a TTY, so captured/piped output stays
+ * plain — which is what non-interactive callers (agents, scripts) want.
+ */
+export function colorEnabled(): boolean {
+  if (process.env.NO_COLOR !== undefined) return false
+  if (process.env.FORCE_COLOR) return true
+  return process.stdout.isTTY === true
+}

--- a/packages/awsesh/src/util/styled-output.test.ts
+++ b/packages/awsesh/src/util/styled-output.test.ts
@@ -80,29 +80,48 @@ describe("printSessionInfo", () => {
     expect(capturedOutput.endsWith("\n\n")).toBe(true);
   });
 
-  test("includes ANSI color codes", () => {
-    printSessionInfo({
-      sessionName: "test",
-      accountName: "Test",
-      accountId: "000000000000",
-      roleName: "Admin",
-      region: "us-east-1",
-    });
+  test("includes ANSI color codes when color is forced", () => {
+    const prev = process.env.FORCE_COLOR;
+    process.env.FORCE_COLOR = "1";
+    try {
+      printSessionInfo({
+        sessionName: "test",
+        accountName: "Test",
+        accountId: "000000000000",
+        roleName: "Admin",
+        region: "us-east-1",
+      });
 
-    expect(capturedOutput).toContain("\x1b[38;2;107;114;128m");
-    expect(capturedOutput).toContain("\x1b[0m");
+      expect(capturedOutput).toContain("\x1b[38;2;107;114;128m");
+      expect(capturedOutput).toContain("\x1b[0m");
+      expect(capturedOutput).toContain("\x1b[2m");
+    } finally {
+      if (prev === undefined) delete process.env.FORCE_COLOR;
+      else process.env.FORCE_COLOR = prev;
+    }
   });
 
-  test("includes dim accountId", () => {
-    printSessionInfo({
-      sessionName: "test",
-      accountName: "Test",
-      accountId: "000000000000",
-      roleName: "Admin",
-      region: "us-east-1",
-    });
+  test("omits ANSI color codes when NO_COLOR is set", () => {
+    const prevNoColor = process.env.NO_COLOR;
+    const prevForce = process.env.FORCE_COLOR;
+    process.env.NO_COLOR = "1";
+    delete process.env.FORCE_COLOR;
+    try {
+      printSessionInfo({
+        sessionName: "test",
+        accountName: "Test",
+        accountId: "000000000000",
+        roleName: "Admin",
+        region: "us-east-1",
+      });
 
-    expect(capturedOutput).toContain("\x1b[2m");
+      expect(capturedOutput).not.toContain("\x1b[");
+      expect(capturedOutput).toContain("Admin");
+    } finally {
+      if (prevNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = prevNoColor;
+      if (prevForce !== undefined) process.env.FORCE_COLOR = prevForce;
+    }
   });
 });
 

--- a/packages/awsesh/src/util/styled-output.ts
+++ b/packages/awsesh/src/util/styled-output.ts
@@ -1,8 +1,5 @@
 import fs from "node:fs"
-
-const RESET = "\x1b[0m"
-const DIM = "\x1b[2m"
-const GRAY = "\x1b[38;2;107;114;128m"
+import { colorEnabled } from "./color"
 
 export interface SessionInfo {
   sessionName: string
@@ -30,6 +27,11 @@ function shellQuote(value: string): string {
 }
 
 export function printSessionInfo(info: SessionInfo): void {
+  const color = colorEnabled()
+  const RESET = color ? "\x1b[0m" : ""
+  const DIM = color ? "\x1b[2m" : ""
+  const GRAY = color ? "\x1b[38;2;107;114;128m" : ""
+
   const lines: string[] = [""]
   lines.push(`${GRAY}Session${RESET}  ${info.sessionName}`)
   lines.push(`${GRAY}Account${RESET}  ${info.accountName} ${DIM}${info.accountId}${RESET}`)


### PR DESCRIPTION
## Summary
Makes `awsesh` friendlier to scripts and agents: adds machine-readable `--json` output to the two commands that lacked it, and makes all ANSI styling respect `NO_COLOR` / non-TTY output.

## Changes
- `whoami --json` / `-j` and `set --json` / `-j` emit structured JSON.
- `set` treats `--json` like `--eval` (`quiet`) so prompts/spinners go to stderr and stdout stays clean.
- New `colorEnabled()` helper: honors `NO_COLOR`, respects `FORCE_COLOR`, otherwise only colors when stdout is a TTY.
- ANSI gated through it in `ui.ts`, the help/logo banner, and `styled-output.ts`.
- `styled-output.test.ts` updated for forced-color + a `NO_COLOR` plain-output test.

## Testing
- `bun run typecheck` ✅
- `bun test` ✅ 203 pass / 0 fail
- Smoke: `whoami --json` emits clean JSON; `--help` piped has zero ANSI escapes; `NO_COLOR=1 whoami` is plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)